### PR TITLE
[AL-3254]Add Login and launch screen in sample app #trivial

### DIFF
--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* KommunicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* KommunicateTests.swift */; };
 		81050FDED97ED682BDA95788 /* Pods_Kommunicate_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02A5491CCF26CCAE37134836 /* Pods_Kommunicate_Example.framework */; };
+		8B33037F2226A494003BF306 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B33037E2226A494003BF306 /* LoginViewController.swift */; };
 		8B5BC12A22002FDC00F39956 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8B5BC12822002FDC00F39956 /* Localizable.strings */; };
 		8B8FFA9421D5171F00C8ED57 /* PaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FFA9321D5171F00C8ED57 /* PaymentTests.swift */; };
 		9B62C0C2E360C245E75858BC /* Pods_Kommunicate_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B1CC9E49975F48B2A2355C6 /* Pods_Kommunicate_Tests.framework */; };
@@ -46,6 +47,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* KommunicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KommunicateTests.swift; sourceTree = "<group>"; };
 		66048B39F43D5FE62EF374B5 /* Kommunicate.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Kommunicate.podspec; path = ../Kommunicate.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		8B33037E2226A494003BF306 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		8B5BC12422002C4000F39956 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8B5BC12522002C4000F39956 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		8B5BC12922002FDC00F39956 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
+				8B33037D2226A43B003BF306 /* Login & Launch */,
 				607FACD31AFB9204008FA782 /* Supporting Files */,
 			);
 			name = "Example for Kommunicate";
@@ -157,6 +160,14 @@
 				A705F6509C85EF919B1A8ED7 /* LICENSE */,
 			);
 			name = "Podspec Metadata";
+			sourceTree = "<group>";
+		};
+		8B33037D2226A43B003BF306 /* Login & Launch */ = {
+			isa = PBXGroup;
+			children = (
+				8B33037E2226A494003BF306 /* LoginViewController.swift */,
+			);
+			name = "Login & Launch";
 			sourceTree = "<group>";
 		};
 		8E5A06963AD79A49983FD533 /* Pods */ = {
@@ -395,6 +406,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B33037F2226A494003BF306 /* LoginViewController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);

--- a/Example/Kommunicate/AppDelegate.swift
+++ b/Example/Kommunicate/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
+    // Pass your App Id here. You can get the App Id from install section in the dashboard.
+    static let appId = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
@@ -23,6 +25,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         KMPushNotificationHandler.shared.dataConnectionNotificationHandlerWith(Kommunicate.defaultConfiguration)
         let kmApplocalNotificationHandler : KMAppLocalNotification =  KMAppLocalNotification.appLocalNotificationHandler()
         kmApplocalNotificationHandler.dataConnectionNotificationHandler()
+
+        if (KMUserDefaultHandler.isLoggedIn())
+        {
+            // Get login screen from storyboard and present it
+            if let viewController = UIStoryboard(name: "Main", bundle: nil)
+                .instantiateViewController(withIdentifier: "NavViewController") as? UINavigationController {
+                self.window?.makeKeyAndVisible();
+                self.window?.rootViewController!.present(viewController, animated:true, completion: nil)
+            }
+        }
 
         if (launchOptions != nil)
         {

--- a/Example/Kommunicate/Base.lproj/Main.storyboard
+++ b/Example/Kommunicate/Base.lproj/Main.storyboard
@@ -64,6 +64,19 @@
                                                             <action selector="getStartedBtn:" destination="Pbo-Hd-r2L" eventType="touchUpInside" id="hHi-u0-2t3"/>
                                                         </connections>
                                                     </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IhW-KT-6ZW">
+                                                        <rect key="frame" x="15" y="476" width="345" height="38"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="38" id="Rj5-ia-CyY"/>
+                                                        </constraints>
+                                                        <state key="normal" title="Login as Visitor">
+                                                            <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="loginAsVisitor:" destination="Pbo-Hd-r2L" eventType="touchUpInside" id="HFZ-Rc-zeB"/>
+                                                        </connections>
+                                                    </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kommunicate Sample App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X3K-bg-emN">
                                                         <rect key="frame" x="10" y="80" width="355" height="22"/>
                                                         <constraints>
@@ -74,17 +87,41 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Or" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jjr-c8-kDh">
+                                                        <rect key="frame" x="178" y="425" width="19" height="21"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="19" id="Anu-6V-cBk"/>
+                                                            <constraint firstAttribute="height" constant="21" id="hLY-O1-qSD"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you Login as a visitor then you don't have to pass a user Id and password. You will be logged in with a random User Id" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tqo-8T-wEX">
+                                                        <rect key="frame" x="15" y="522" width="345" height="29"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
                                                 </subviews>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstItem="qRU-af-vN7" firstAttribute="top" secondItem="mSt-We-A0W" secondAttribute="bottom" constant="50" id="57l-UI-laE"/>
+                                                    <constraint firstItem="IhW-KT-6ZW" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="AYu-Hv-gMI"/>
+                                                    <constraint firstItem="Jjr-c8-kDh" firstAttribute="top" secondItem="qRU-af-vN7" secondAttribute="bottom" constant="30" id="BMg-Oy-hkq"/>
                                                     <constraint firstAttribute="trailing" secondItem="mSt-We-A0W" secondAttribute="trailing" constant="15" id="FLv-Cp-sB1"/>
+                                                    <constraint firstItem="Jjr-c8-kDh" firstAttribute="centerX" secondItem="qRU-af-vN7" secondAttribute="centerX" id="KsP-VU-S2t"/>
                                                     <constraint firstItem="X3K-bg-emN" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="10" id="Np7-8Q-Xpy"/>
+                                                    <constraint firstItem="tqo-8T-wEX" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="O3e-rj-SV7"/>
+                                                    <constraint firstAttribute="trailing" secondItem="tqo-8T-wEX" secondAttribute="trailing" constant="15" id="Pyx-XQ-S8s"/>
                                                     <constraint firstAttribute="trailing" secondItem="qRU-af-vN7" secondAttribute="trailing" constant="15" id="QL3-el-aZs"/>
                                                     <constraint firstItem="mSt-We-A0W" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="Sgp-s0-ZLy"/>
+                                                    <constraint firstItem="IhW-KT-6ZW" firstAttribute="top" secondItem="Jjr-c8-kDh" secondAttribute="bottom" constant="30" id="ZFH-Yo-UOq"/>
+                                                    <constraint firstItem="tqo-8T-wEX" firstAttribute="top" secondItem="IhW-KT-6ZW" secondAttribute="bottom" constant="8" id="anX-ag-AII"/>
                                                     <constraint firstItem="qRU-af-vN7" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="dwa-3G-e23"/>
                                                     <constraint firstItem="qRU-af-vN7" firstAttribute="centerY" secondItem="V0H-EM-7CR" secondAttribute="centerY" constant="40" id="fD4-Pc-6Y1"/>
                                                     <constraint firstItem="X3K-bg-emN" firstAttribute="top" secondItem="V0H-EM-7CR" secondAttribute="top" constant="80" id="fD5-3l-EI7"/>
+                                                    <constraint firstAttribute="trailing" secondItem="IhW-KT-6ZW" secondAttribute="trailing" constant="15" id="hl7-Ev-YnW"/>
                                                     <constraint firstAttribute="trailing" secondItem="X3K-bg-emN" secondAttribute="trailing" constant="10" id="j3N-DF-dJr"/>
                                                 </constraints>
                                             </view>
@@ -117,7 +154,9 @@
                     </view>
                     <navigationItem key="navigationItem" id="aB8-D4-8VU"/>
                     <connections>
+                        <outlet property="activityIndicator" destination="w1a-yR-ixw" id="dU3-Z0-Ed2"/>
                         <outlet property="emailId" destination="leR-dq-agW" id="ve3-vW-YZe"/>
+                        <outlet property="loginAsVisitorButton" destination="IhW-KT-6ZW" id="VwO-xu-zuL"/>
                         <outlet property="password" destination="xme-mF-3j3" id="tep-tF-bhh"/>
                         <outlet property="userName" destination="RlE-qT-f7W" id="UvT-te-bYx"/>
                     </connections>
@@ -139,25 +178,27 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="45" translatesAutoresizingMaskIntoConstraints="NO" id="y8r-rN-lWt">
-                                <rect key="frame" x="26" y="226" width="323" height="175"/>
+                                <rect key="frame" x="26" y="251" width="323" height="125"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dLS-vh-glM">
-                                        <rect key="frame" x="11.5" y="0.0" width="300" height="80"/>
+                                        <rect key="frame" x="11.5" y="0.0" width="300" height="40"/>
+                                        <color key="backgroundColor" red="0.08235294118" green="0.53333333329999999" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="GyF-GG-sDu"/>
-                                            <constraint firstAttribute="height" constant="80" id="mJZ-zc-ucj"/>
+                                            <constraint firstAttribute="height" constant="40" id="mJZ-zc-ucj"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                        <state key="normal" title="Launch Conversations"/>
+                                        <state key="normal" title="Launch Conversations">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
                                         <connections>
                                             <action selector="launchConversation:" destination="X0S-4o-tJq" eventType="touchUpInside" id="cJK-Bp-Fju"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H1w-vp-gBV">
-                                        <rect key="frame" x="111.5" y="125" width="100" height="50"/>
+                                        <rect key="frame" x="11.5" y="85" width="300" height="40"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="LcB-DP-Yba"/>
-                                            <constraint firstAttribute="height" constant="50" id="WQ4-1U-ji6"/>
+                                            <constraint firstAttribute="height" constant="40" id="WQ4-1U-ji6"/>
                                         </constraints>
                                         <state key="normal" title="Logout"/>
                                         <connections>
@@ -165,6 +206,9 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="H1w-vp-gBV" firstAttribute="width" secondItem="dLS-vh-glM" secondAttribute="width" id="MtW-7p-qT9"/>
+                                </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kommunicate Sample App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U4k-ig-LW4">
                                 <rect key="frame" x="26" y="94" width="323" height="22"/>

--- a/Example/Kommunicate/Base.lproj/Main.storyboard
+++ b/Example/Kommunicate/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f60-be-cnY">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="f60-be-cnY">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="674"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q98-oe-vjs">
@@ -64,23 +64,33 @@
                                                             <action selector="getStartedBtn:" destination="Pbo-Hd-r2L" eventType="touchUpInside" id="hHi-u0-2t3"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IhW-KT-6ZW">
-                                                        <rect key="frame" x="15" y="476" width="345" height="38"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="38" id="Rj5-ia-CyY"/>
-                                                        </constraints>
-                                                        <state key="normal" title="Login as Visitor">
-                                                            <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
-                                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="loginAsVisitor:" destination="Pbo-Hd-r2L" eventType="touchUpInside" id="HFZ-Rc-zeB"/>
-                                                        </connections>
-                                                    </button>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="23M-bc-Mf5">
+                                                        <rect key="frame" x="15" y="476" width="345" height="75"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IhW-KT-6ZW">
+                                                                <rect key="frame" x="0.0" y="0.0" width="345" height="38"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="38" id="Rj5-ia-CyY"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Login as Visitor">
+                                                                    <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                </state>
+                                                                <connections>
+                                                                    <action selector="loginAsVisitor:" destination="Pbo-Hd-r2L" eventType="touchUpInside" id="HFZ-Rc-zeB"/>
+                                                                </connections>
+                                                            </button>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you Login as a visitor then you don't have to pass a user Id and password. You will be logged in with a random User Id" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tqo-8T-wEX">
+                                                                <rect key="frame" x="0.0" y="46" width="345" height="29"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kommunicate Sample App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X3K-bg-emN">
                                                         <rect key="frame" x="10" y="80" width="355" height="22"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="jWL-Kt-u77"/>
                                                             <constraint firstAttribute="height" constant="22" id="pMe-QX-5oR"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -90,39 +100,30 @@
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Or" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jjr-c8-kDh">
                                                         <rect key="frame" x="178" y="425" width="19" height="21"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="19" id="Anu-6V-cBk"/>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="19" id="Anu-6V-cBk"/>
                                                             <constraint firstAttribute="height" constant="21" id="hLY-O1-qSD"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you Login as a visitor then you don't have to pass a user Id and password. You will be logged in with a random User Id" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tqo-8T-wEX">
-                                                        <rect key="frame" x="15" y="522" width="345" height="29"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
                                                 </subviews>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
+                                                    <constraint firstItem="23M-bc-Mf5" firstAttribute="top" secondItem="Jjr-c8-kDh" secondAttribute="bottom" constant="30" id="0MB-H6-5D0"/>
                                                     <constraint firstItem="qRU-af-vN7" firstAttribute="top" secondItem="mSt-We-A0W" secondAttribute="bottom" constant="50" id="57l-UI-laE"/>
-                                                    <constraint firstItem="IhW-KT-6ZW" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="AYu-Hv-gMI"/>
                                                     <constraint firstItem="Jjr-c8-kDh" firstAttribute="top" secondItem="qRU-af-vN7" secondAttribute="bottom" constant="30" id="BMg-Oy-hkq"/>
                                                     <constraint firstAttribute="trailing" secondItem="mSt-We-A0W" secondAttribute="trailing" constant="15" id="FLv-Cp-sB1"/>
-                                                    <constraint firstItem="Jjr-c8-kDh" firstAttribute="centerX" secondItem="qRU-af-vN7" secondAttribute="centerX" id="KsP-VU-S2t"/>
+                                                    <constraint firstItem="23M-bc-Mf5" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="KYT-T1-rBo"/>
                                                     <constraint firstItem="X3K-bg-emN" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="10" id="Np7-8Q-Xpy"/>
-                                                    <constraint firstItem="tqo-8T-wEX" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="O3e-rj-SV7"/>
-                                                    <constraint firstAttribute="trailing" secondItem="tqo-8T-wEX" secondAttribute="trailing" constant="15" id="Pyx-XQ-S8s"/>
                                                     <constraint firstAttribute="trailing" secondItem="qRU-af-vN7" secondAttribute="trailing" constant="15" id="QL3-el-aZs"/>
                                                     <constraint firstItem="mSt-We-A0W" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="Sgp-s0-ZLy"/>
-                                                    <constraint firstItem="IhW-KT-6ZW" firstAttribute="top" secondItem="Jjr-c8-kDh" secondAttribute="bottom" constant="30" id="ZFH-Yo-UOq"/>
-                                                    <constraint firstItem="tqo-8T-wEX" firstAttribute="top" secondItem="IhW-KT-6ZW" secondAttribute="bottom" constant="8" id="anX-ag-AII"/>
                                                     <constraint firstItem="qRU-af-vN7" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="dwa-3G-e23"/>
                                                     <constraint firstItem="qRU-af-vN7" firstAttribute="centerY" secondItem="V0H-EM-7CR" secondAttribute="centerY" constant="40" id="fD4-Pc-6Y1"/>
                                                     <constraint firstItem="X3K-bg-emN" firstAttribute="top" secondItem="V0H-EM-7CR" secondAttribute="top" constant="80" id="fD5-3l-EI7"/>
-                                                    <constraint firstAttribute="trailing" secondItem="IhW-KT-6ZW" secondAttribute="trailing" constant="15" id="hl7-Ev-YnW"/>
                                                     <constraint firstAttribute="trailing" secondItem="X3K-bg-emN" secondAttribute="trailing" constant="10" id="j3N-DF-dJr"/>
+                                                    <constraint firstAttribute="trailing" secondItem="23M-bc-Mf5" secondAttribute="trailing" constant="15" id="k3i-bE-kQm"/>
+                                                    <constraint firstItem="Jjr-c8-kDh" firstAttribute="centerX" secondItem="V0H-EM-7CR" secondAttribute="centerX" id="xOI-aM-TSi"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -158,6 +159,7 @@
                         <outlet property="emailId" destination="leR-dq-agW" id="ve3-vW-YZe"/>
                         <outlet property="loginAsVisitorButton" destination="IhW-KT-6ZW" id="VwO-xu-zuL"/>
                         <outlet property="password" destination="xme-mF-3j3" id="tep-tF-bhh"/>
+                        <outlet property="scrollView" destination="f60-be-cnY" id="w1m-A3-pra"/>
                         <outlet property="userName" destination="RlE-qT-f7W" id="UvT-te-bYx"/>
                     </connections>
                 </viewController>

--- a/Example/Kommunicate/Base.lproj/Main.storyboard
+++ b/Example/Kommunicate/Base.lproj/Main.storyboard
@@ -1,50 +1,214 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14101" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="cYR-If-EkG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Pbo-Hd-r2L">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="ufC-wZ-h7g">
+        <!--Login View Controller-->
+        <scene sceneID="MPR-78-3E7">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="Kommunicate_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginView" id="Pbo-Hd-r2L" customClass="LoginViewController" customModule="Kommunicate_Example" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
-                        <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
+                        <viewControllerLayoutGuide type="top" id="Rfe-0f-9qm"/>
+                        <viewControllerLayoutGuide type="bottom" id="EHN-Ml-6v9"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
+                    <view key="view" contentMode="scaleToFill" restorationIdentifier="ALLoginViewController" id="5Sh-My-p2O">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f60-be-cnY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="674"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q98-oe-vjs">
+                                        <rect key="frame" x="0.0" y="1" width="375" height="672"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V0H-EM-7CR">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="672"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mSt-We-A0W">
+                                                        <rect key="frame" x="15" y="177" width="345" height="130"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="User id (Use a random id for the first time login)" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RlE-qT-f7W">
+                                                                <rect key="frame" x="0.0" y="0.0" width="345" height="30"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                            </textField>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email (Optional)" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="leR-dq-agW">
+                                                                <rect key="frame" x="0.0" y="50" width="345" height="30"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                            </textField>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xme-mF-3j3">
+                                                                <rect key="frame" x="0.0" y="100" width="345" height="30"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
+                                                            </textField>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qRU-af-vN7">
+                                                        <rect key="frame" x="15" y="357" width="345" height="38"/>
+                                                        <color key="backgroundColor" red="0.08235294118" green="0.53333333329999999" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="38" id="syV-x8-uvr"/>
+                                                        </constraints>
+                                                        <state key="normal" title="Get Started">
+                                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="getStartedBtn:" destination="Pbo-Hd-r2L" eventType="touchUpInside" id="hHi-u0-2t3"/>
+                                                        </connections>
+                                                    </button>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kommunicate Sample App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X3K-bg-emN">
+                                                        <rect key="frame" x="10" y="80" width="355" height="22"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="jWL-Kt-u77"/>
+                                                            <constraint firstAttribute="height" constant="22" id="pMe-QX-5oR"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstItem="qRU-af-vN7" firstAttribute="top" secondItem="mSt-We-A0W" secondAttribute="bottom" constant="50" id="57l-UI-laE"/>
+                                                    <constraint firstAttribute="trailing" secondItem="mSt-We-A0W" secondAttribute="trailing" constant="15" id="FLv-Cp-sB1"/>
+                                                    <constraint firstItem="X3K-bg-emN" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="10" id="Np7-8Q-Xpy"/>
+                                                    <constraint firstAttribute="trailing" secondItem="qRU-af-vN7" secondAttribute="trailing" constant="15" id="QL3-el-aZs"/>
+                                                    <constraint firstItem="mSt-We-A0W" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="Sgp-s0-ZLy"/>
+                                                    <constraint firstItem="qRU-af-vN7" firstAttribute="leading" secondItem="V0H-EM-7CR" secondAttribute="leading" constant="15" id="dwa-3G-e23"/>
+                                                    <constraint firstItem="qRU-af-vN7" firstAttribute="centerY" secondItem="V0H-EM-7CR" secondAttribute="centerY" constant="40" id="fD4-Pc-6Y1"/>
+                                                    <constraint firstItem="X3K-bg-emN" firstAttribute="top" secondItem="V0H-EM-7CR" secondAttribute="top" constant="80" id="fD5-3l-EI7"/>
+                                                    <constraint firstAttribute="trailing" secondItem="X3K-bg-emN" secondAttribute="trailing" constant="10" id="j3N-DF-dJr"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
+                                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-yR-ixw">
+                                        <rect key="frame" x="177.5" y="327" width="20" height="20"/>
+                                        <rect key="contentStretch" x="1" y="1" width="1" height="1"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="w1a-yR-ixw" firstAttribute="centerY" secondItem="f60-be-cnY" secondAttribute="centerY" id="38I-PQ-yMF"/>
+                                    <constraint firstItem="w1a-yR-ixw" firstAttribute="centerX" secondItem="q98-oe-vjs" secondAttribute="centerX" id="GVf-PC-cZS"/>
+                                    <constraint firstItem="q98-oe-vjs" firstAttribute="top" secondItem="f60-be-cnY" secondAttribute="top" constant="1" id="OgR-dV-kE2"/>
+                                    <constraint firstAttribute="bottom" secondItem="q98-oe-vjs" secondAttribute="bottom" constant="-1" id="TYa-e1-3XM"/>
+                                    <constraint firstItem="w1a-yR-ixw" firstAttribute="centerY" secondItem="q98-oe-vjs" secondAttribute="centerY" id="WqD-Sb-f7U"/>
+                                    <constraint firstAttribute="trailing" secondItem="q98-oe-vjs" secondAttribute="trailing" id="acD-uw-Rg6"/>
+                                    <constraint firstItem="q98-oe-vjs" firstAttribute="leading" secondItem="f60-be-cnY" secondAttribute="leading" id="dh9-Wa-V41"/>
+                                    <constraint firstItem="w1a-yR-ixw" firstAttribute="centerX" secondItem="f60-be-cnY" secondAttribute="centerX" id="vTe-XW-Etr"/>
+                                </constraints>
+                            </scrollView>
+                        </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="f60-be-cnY" firstAttribute="top" secondItem="5Sh-My-p2O" secondAttribute="top" id="1LF-5l-RBe"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="f60-be-cnY" secondAttribute="bottom" constant="-7" id="Fpk-IX-1EO"/>
+                            <constraint firstAttribute="trailing" secondItem="f60-be-cnY" secondAttribute="trailing" id="NUK-bL-2K6"/>
+                            <constraint firstItem="f60-be-cnY" firstAttribute="leading" secondItem="5Sh-My-p2O" secondAttribute="leading" id="ai8-gA-Wfe"/>
+                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="cwB-mR-kjx"/>
+                    <navigationItem key="navigationItem" id="aB8-D4-8VU"/>
+                    <connections>
+                        <outlet property="emailId" destination="leR-dq-agW" id="ve3-vW-YZe"/>
+                        <outlet property="password" destination="xme-mF-3j3" id="tep-tF-bhh"/>
+                        <outlet property="userName" destination="RlE-qT-f7W" id="UvT-te-bYx"/>
+                    </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Rwi-kT-Zz7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1076" y="114.69265367316342"/>
+            <point key="canvasLocation" x="-1508" y="475"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="POh-ek-JYw">
+            <objects>
+                <viewController storyboardIdentifier="ViewController" id="X0S-4o-tJq" customClass="ViewController" customModule="Kommunicate_Example" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="iiO-J1-rhb"/>
+                        <viewControllerLayoutGuide type="bottom" id="QU6-NT-MU9"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="puZ-fv-UFj">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="45" translatesAutoresizingMaskIntoConstraints="NO" id="y8r-rN-lWt">
+                                <rect key="frame" x="26" y="226" width="323" height="175"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dLS-vh-glM">
+                                        <rect key="frame" x="11.5" y="0.0" width="300" height="80"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="GyF-GG-sDu"/>
+                                            <constraint firstAttribute="height" constant="80" id="mJZ-zc-ucj"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <state key="normal" title="Launch Conversations"/>
+                                        <connections>
+                                            <action selector="launchConversation:" destination="X0S-4o-tJq" eventType="touchUpInside" id="cJK-Bp-Fju"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H1w-vp-gBV">
+                                        <rect key="frame" x="111.5" y="125" width="100" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="LcB-DP-Yba"/>
+                                            <constraint firstAttribute="height" constant="50" id="WQ4-1U-ji6"/>
+                                        </constraints>
+                                        <state key="normal" title="Logout"/>
+                                        <connections>
+                                            <action selector="logoutAction:" destination="X0S-4o-tJq" eventType="touchUpInside" id="7Hn-eN-oyY"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kommunicate Sample App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U4k-ig-LW4">
+                                <rect key="frame" x="26" y="94" width="323" height="22"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="22" id="qkT-MZ-b56"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="U4k-ig-LW4" firstAttribute="leading" secondItem="puZ-fv-UFj" secondAttribute="leadingMargin" constant="10" id="23x-ii-v56"/>
+                            <constraint firstItem="y8r-rN-lWt" firstAttribute="centerY" secondItem="puZ-fv-UFj" secondAttribute="centerY" constant="-20" id="5iK-Vd-e5m"/>
+                            <constraint firstItem="U4k-ig-LW4" firstAttribute="top" secondItem="iiO-J1-rhb" secondAttribute="bottom" constant="30" id="KbP-wI-dfC"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="U4k-ig-LW4" secondAttribute="trailing" constant="10" id="Yuw-1b-25I"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="y8r-rN-lWt" secondAttribute="trailing" constant="10" id="ZiK-iO-08f"/>
+                            <constraint firstItem="y8r-rN-lWt" firstAttribute="leading" secondItem="puZ-fv-UFj" secondAttribute="leadingMargin" constant="10" id="g71-2N-NWx"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="5eA-EJ-IaU"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="XOp-Y6-Jc3" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="252" y="474.51274362818594"/>
         </scene>
         <!--Navigation Controller-->
-        <scene sceneID="xxs-l5-A7a">
+        <scene sceneID="qsO-Tc-fQ7">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="cYR-If-EkG" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="NavViewController" automaticallyAdjustsScrollViewInsets="NO" id="PHm-86-jF3" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="kSA-cQ-HpA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="TAx-Td-pqK">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="vXZ-lx-hvc" kind="relationship" relationship="rootViewController" id="et9-nO-uiz"/>
+                        <segue destination="X0S-4o-tJq" kind="relationship" relationship="rootViewController" id="oM4-HT-Gnf"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="yht-CC-D2X" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="et3-PT-wax" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="136.80000000000001" y="773.16341829085468"/>
+            <point key="canvasLocation" x="-687.20000000000005" y="474.51274362818594"/>
         </scene>
     </scenes>
 </document>

--- a/Example/Kommunicate/Info.plist
+++ b/Example/Kommunicate/Info.plist
@@ -30,10 +30,10 @@
 	<string>Please allow Location Services to determine your location.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>$(PRODUCT_NAME) request audio use</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Allow write access</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(PRODUCT_NAME) photo use</string>
-    <key>NSPhotoLibraryAddUsageDescription</key>
-    <string>Allow write access</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
@@ -50,7 +50,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
 </dict>
 </plist>

--- a/Example/Kommunicate/LoginViewController.swift
+++ b/Example/Kommunicate/LoginViewController.swift
@@ -1,0 +1,84 @@
+//
+//  LoginViewController.swift
+//  Kommunicate_Example
+//
+//  Created by Mukesh on 27/02/19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import Kommunicate
+
+class LoginViewController: UIViewController {
+
+    @IBOutlet weak var userName: UITextField!
+    @IBOutlet weak var password: UITextField!
+
+    @IBOutlet weak var emailId: UITextField!
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+        KMUserDefaultHandler.setUserAuthenticationTypeId(1) // APPLOZIC
+
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+    @IBAction func getStartedBtn(_ sender: AnyObject) {
+        let kmUser = KMUser()
+        let applicationId = AppDelegate.appId
+        guard !applicationId.isEmpty else {
+            fatalError("Please pass your AppId in the AppDelegate file.")
+        }
+
+        Kommunicate.setup(applicationId: applicationId)
+        kmUser.applicationId = applicationId
+
+        guard let userIdEntered = userName.text, !userIdEntered.isEmpty else {
+            let alertMessage = "Please enter a userId. If you are trying the app for the first time then just enter a random Id"
+            let alert = UIAlertController(
+                title: "Kommunicate login",
+                message: alertMessage,
+                preferredStyle: UIAlertController.Style.alert)
+            alert.addAction(UIAlertAction(title: "Okay", style: UIAlertAction.Style.default, handler: nil))
+            self.present(alert, animated: true, completion: nil)
+            return
+        }
+        kmUser.userId = self.userName.text
+        KMUserDefaultHandler.setUserId(kmUser.userId)
+
+        print("userName:: " , kmUser.userId)
+        if(!((emailId.text?.isEmpty)!)){
+            kmUser.email = emailId.text
+            KMUserDefaultHandler.setEmailId(kmUser.email)
+        }
+
+        if (!((password.text?.isEmpty)!)){
+            kmUser.password = password.text
+            KMUserDefaultHandler.setPassword(kmUser.password)
+        }
+        registerUser(kmUser)
+    }
+
+    private func registerUser(_ kmUser: KMUser) {
+        Kommunicate.registerUser(kmUser, completion: {
+            response, error in
+            guard error == nil else {
+                NSLog("[REGISTRATION] Kommunicate user registration error: %@", error.debugDescription)
+                return
+            }
+            NSLog("User registration was successful: %@ \(String(describing: response?.isRegisteredSuccessfully()))")
+            if let viewController = UIStoryboard(name: "Main", bundle: nil)
+                .instantiateViewController(withIdentifier: "NavViewController") as? UINavigationController {
+                self.present(viewController, animated:true, completion: nil)
+            }
+        })
+    }
+}

--- a/Example/Kommunicate/LoginViewController.swift
+++ b/Example/Kommunicate/LoginViewController.swift
@@ -11,6 +11,7 @@ import Kommunicate
 
 class LoginViewController: UIViewController {
 
+    @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var userName: UITextField!
     @IBOutlet weak var password: UITextField!
 
@@ -19,14 +20,22 @@ class LoginViewController: UIViewController {
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     @IBOutlet weak var loginAsVisitorButton: UIButton!
 
+    // To avoid scrolling up multiple times when a different text field is active.
+    var isKeyboardVisible = false
+    var originalContentInset: UIEdgeInsets = .zero
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         loginAsVisitorButton.layer.borderWidth = 1
         loginAsVisitorButton.layer.borderColor = UIColor(hexString: "1588B2")?.cgColor
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     @IBAction func getStartedBtn(_ sender: AnyObject) {
+        resignFields()
         let applicationId = AppDelegate.appId
         setupApplicationKey(applicationId)
 
@@ -42,7 +51,7 @@ class LoginViewController: UIViewController {
         }
         let kmUser = userWithUserId(userIdEntered, andApplicationId: applicationId)
 
-        print("userName:: " , kmUser.userId)
+        print("userId:: ", kmUser.userId)
         if(!((emailId.text?.isEmpty)!)){
             kmUser.email = emailId.text
         }
@@ -54,11 +63,51 @@ class LoginViewController: UIViewController {
     }
 
     @IBAction func loginAsVisitor(_ sender: Any) {
+        resignFields()
         let applicationId = AppDelegate.appId
         setupApplicationKey(applicationId)
 
         let kmUser = userWithUserId(Kommunicate.randomId(), andApplicationId: applicationId)
         registerUser(kmUser)
+    }
+
+    @objc func keyboardWillHide(notification: NSNotification) {
+
+        guard isKeyboardVisible,
+            let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval
+            else { return }
+        isKeyboardVisible = false
+        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState], animations: {
+            self.scrollView.contentInset = self.originalContentInset
+            self.scrollView.scrollIndicatorInsets = self.originalContentInset
+            self.scrollView.contentOffset = CGPoint(x: 0, y: 0)
+        })
+    }
+
+    @objc func keyboardWillShow(notification: NSNotification) {
+
+        guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { return }
+        var inset = scrollView.contentInset
+        originalContentInset = inset
+
+        // This will convert the rect. w.r.t to the current view.
+        let converted = self.view.convert(frame, from: nil)
+        let intersection = converted.intersection(frame)
+        // This will give us the value of how much to move up.
+        var bottomInset = intersection.height
+        if #available(iOS 11.0, *) {
+             bottomInset = bottomInset - self.view.safeAreaInsets.bottom
+        }
+
+        inset.bottom = bottomInset
+        guard !isKeyboardVisible else { return }
+        isKeyboardVisible = true
+        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState], animations: {
+            self.scrollView.contentInset = inset
+            self.scrollView.scrollIndicatorInsets = inset
+            self.scrollView.contentOffset = CGPoint(x: 0, y: bottomInset - 60)
+        })
     }
 
     private func setupApplicationKey(_ applicationId: String) {
@@ -83,14 +132,20 @@ class LoginViewController: UIViewController {
             response, error in
             self.activityIndicator.stopAnimating()
             guard error == nil else {
-                NSLog("[REGISTRATION] Kommunicate user registration error: %@", error.debugDescription)
+                print("[REGISTRATION] Kommunicate user registration error: %@", error.debugDescription)
                 return
             }
-            NSLog("User registration was successful: %@ \(String(describing: response?.isRegisteredSuccessfully()))")
+            print("User registration was successful: %@ \(String(describing: response?.isRegisteredSuccessfully()))")
             if let viewController = UIStoryboard(name: "Main", bundle: nil)
                 .instantiateViewController(withIdentifier: "NavViewController") as? UINavigationController {
                 self.present(viewController, animated:true, completion: nil)
             }
         })
+    }
+
+    private func resignFields() {
+        userName.resignFirstResponder()
+        emailId.resignFirstResponder()
+        password.resignFirstResponder()
     }
 }

--- a/Example/Kommunicate/ViewController.swift
+++ b/Example/Kommunicate/ViewController.swift
@@ -13,43 +13,18 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let userId = "testabc"
-        let applicationKey = "<Pass your application key>"
-        Kommunicate.setup(applicationId: applicationKey)
-        if Kommunicate.isLoggedIn {
-            Kommunicate.createConversation(
-                userId: userId,
-                botIds: nil,
-                useLastConversation: true,
-                completion: { response in
-                    guard !response.isEmpty else {return}
-                    DispatchQueue.main.async {
-                        Kommunicate.showConversationWith(groupId: response, from: self, completionHandler: { success in
-                            print("conversation was shown")
-                        })
-                    }
-                })
-        } else {
-            let kmUser = KMUser()
-            kmUser.userId = userId
-            kmUser.applicationId = applicationKey
+    }
 
-            Kommunicate.registerUser(kmUser, completion: {
-                response, error in
-                guard error == nil else {return}
-                Kommunicate.createConversation(
-                    userId: kmUser.userId,
-                    botIds: nil,
-                    useLastConversation: true,
-                    completion: { response in
-                    guard !response.isEmpty else {return}
-                        DispatchQueue.main.async {
-                            Kommunicate.showConversationWith(groupId: response, from: self, completionHandler: { success in
-                                print("conversation was shown")
-                            })
-                        }
-                })
-            })
-        }
+    @IBAction func launchConversation(_ sender: Any) {
+        Kommunicate.createAndShowConversation(from: self, completion: {
+            error in
+            if error != nil {
+                print("Error while launching")
+            }
+        })
+    }
+    @IBAction func logoutAction(_ sender: Any) {
+        Kommunicate.logoutUser()
+        self.dismiss(animated: false, completion: nil)
     }
 }


### PR DESCRIPTION
- Added login view which has three fields: user, email and password.
- Plus 'Login as Visitor' button to login without any user Id for trying the sample app.
- A screen to launch the chat and log out.
- Tested as a new and old user plus as a visitor. All are working fine in the sample app.
- To test the sample app pass application Id in the AppDelegate file and then run the app.