### PR TITLE
[AL-3071] Show conversation assignee in conversation list screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 
 - [AL-2993] Updated Kommunicate framework to Swift 4.2.
+- [AL-3071] Added support to show conversation assignee details in conversation list screen.
 
 1.1.0
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Applozic (6.7.1):
+  - Applozic (6.8.2):
     - SDWebImage (~> 4.4)
-  - ApplozicSwift (2.2.0):
-    - Applozic (~> 6.7.1)
+  - ApplozicSwift (2.3.0):
+    - Applozic (~> 6.8.2)
     - Kingfisher (~> 4.7.0)
     - MGSwipeTableCell (~> 1.5.6)
   - FBSnapshotTestCase (2.1.4):
@@ -17,7 +17,7 @@ PODS:
     - iOSSnapshotTestCase/Core
   - Kingfisher (4.7.0)
   - Kommunicate (1.1.0):
-    - ApplozicSwift (~> 2.2.0)
+    - ApplozicSwift (~> 2.3.0)
   - MGSwipeTableCell (1.5.6)
   - Nimble (7.3.1)
   - Nimble-Snapshots (6.9.0):
@@ -26,9 +26,9 @@ PODS:
     - iOSSnapshotTestCase (~> 4.0)
     - Nimble (~> 7.0)
   - Quick (1.3.2)
-  - SDWebImage (4.4.5):
-    - SDWebImage/Core (= 4.4.5)
-  - SDWebImage/Core (4.4.5)
+  - SDWebImage (4.4.6):
+    - SDWebImage/Core (= 4.4.6)
+  - SDWebImage/Core (4.4.6)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (~> 2.1.4)
@@ -55,17 +55,17 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Applozic: 34eb4a251d9e57daedc084ab78ed59dc8c096791
-  ApplozicSwift: 88921957547420ad471d2e0e44758e2ea2735e7c
+  Applozic: d16300c97171523445827e8f28cb382049146c7e
+  ApplozicSwift: fcedddaeba4b1f62f6c474cd823fdb6a73ae0e7c
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: f3b2b7e606fe03fdbe49af84316bd235df32dc44
   Kingfisher: da6b005aa96d37698e3e4f1ccfe96a5b9bbf27d6
-  Kommunicate: 412288b299e99dc36a8b69df6a6e6ce2027523c7
+  Kommunicate: d9d89f54b8187bba339120b17d3a76ddd2971f53
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Nimble-Snapshots: 79394f8d0aea3df54bd5ff78ee9dff05a523a09c
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
-  SDWebImage: ecc03494e973b93b80213649d32175f8d2d17d4d
+  SDWebImage: 3f3f0c02f09798048c47a5ed0a13f17b063572d8
 
 PODFILE CHECKSUM: dc4c8879e4b38387271291b5935272ba668a0818
 

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.swift_version = '4.2'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json}'
-  s.dependency 'ApplozicSwift', '~> 2.2.0'
+  s.dependency 'ApplozicSwift', '~> 2.3.0'
 end

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -174,6 +174,13 @@ open class Kommunicate: NSObject {
      */
     @objc open class func showConversations(from viewController: UIViewController) {
         let conversationVC = ALKConversationListViewController(configuration: Kommunicate.defaultConfiguration)
+        conversationVC.conversationListTableViewController.dataSource.cellConfigurator = {
+            (messageModel, tableCell) in
+            let cell = tableCell as! ALKChatCell
+            let message = ChatMessage(message: messageModel)
+            cell.update(viewModel: message, identity: nil)
+            cell.chatCellDelegate = conversationVC.conversationListTableViewController.self
+        }
         let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration)
         conversationViewController.kmConversationViewConfiguration = kmConversationViewConfiguration
         conversationVC.conversationViewController = conversationViewController
@@ -322,4 +329,56 @@ open class Kommunicate: NSObject {
         ALApplozicSettings.setSwiftFramework(true)
         ALApplozicSettings.hideMessages(withMetadataKeys: ["KM_ASSIGN", "KM_STATUS"])
     }
+}
+
+class ChatMessage: ALKChatViewModelProtocol {
+    var avatar: URL?
+
+    var avatarImage: UIImage?
+
+    var avatarGroupImageUrl: String?
+
+    var name: String
+
+    var groupName: String
+
+    var theLastMessage: String?
+
+    var hasUnreadMessages: Bool
+
+    var totalNumberOfUnreadMessages: UInt
+
+    var isGroupChat: Bool
+
+    var contactId: String?
+
+    var channelKey: NSNumber?
+
+    var conversationId: NSNumber!
+
+    var createdAt: String?
+
+    init(message: ALKChatViewModelProtocol) {
+        self.avatar = message.avatar
+        self.avatarImage = message.avatarImage
+        self.avatarGroupImageUrl = message.avatarGroupImageUrl
+        self.name = message.name
+        self.groupName = message.groupName
+        self.theLastMessage = message.theLastMessage
+        self.hasUnreadMessages = message.hasUnreadMessages
+        self.totalNumberOfUnreadMessages = message.totalNumberOfUnreadMessages
+        self.isGroupChat = message.isGroupChat
+        self.contactId = message.contactId
+        self.channelKey = message.channelKey
+        self.conversationId = message.conversationId
+        self.createdAt = message.createdAt
+        // Update message to show conversation assignee details
+        guard
+            isGroupChat,
+            let assignee = ConversationDetail().conversationAssignee(groupId: self.channelKey)
+            else { return }
+        self.groupName = assignee.getDisplayName()
+        self.avatarGroupImageUrl = assignee.contactImageUrl
+    }
+
 }

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -166,13 +166,10 @@ open class Kommunicate: NSObject {
         }
     }
 
-    /**
-     Launch chat list from a ViewController.
-
-     - Parameters:
-        - viewController: ViewController from which the chat list will be launched.
-     */
-    @objc open class func showConversations(from viewController: UIViewController) {
+    /// This method is used to return an instance of conversation list view controller.
+    ///
+    /// - Returns: Instance of `ALKConversationListViewController`
+    @objc open class func conversationListViewController() -> ALKConversationListViewController {
         let conversationVC = ALKConversationListViewController(configuration: Kommunicate.defaultConfiguration)
         conversationVC.conversationListTableViewController.dataSource.cellConfigurator = {
             (messageModel, tableCell) in
@@ -184,6 +181,17 @@ open class Kommunicate: NSObject {
         let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration)
         conversationViewController.kmConversationViewConfiguration = kmConversationViewConfiguration
         conversationVC.conversationViewController = conversationViewController
+        return conversationVC
+    }
+
+    /**
+     Launch chat list from a ViewController.
+
+     - Parameters:
+        - viewController: ViewController from which the chat list will be launched.
+     */
+    @objc open class func showConversations(from viewController: UIViewController) {
+        let conversationVC = conversationListViewController()
         let navVC = ALKBaseNavigationViewController(rootViewController: conversationVC)
         viewController.present(navVC, animated: false, completion: nil)
     }
@@ -332,30 +340,19 @@ open class Kommunicate: NSObject {
 }
 
 class ChatMessage: ALKChatViewModelProtocol {
+    var messageType: ALKMessageType
     var avatar: URL?
-
     var avatarImage: UIImage?
-
     var avatarGroupImageUrl: String?
-
     var name: String
-
     var groupName: String
-
     var theLastMessage: String?
-
     var hasUnreadMessages: Bool
-
     var totalNumberOfUnreadMessages: UInt
-
     var isGroupChat: Bool
-
     var contactId: String?
-
     var channelKey: NSNumber?
-
     var conversationId: NSNumber!
-
     var createdAt: String?
 
     init(message: ALKChatViewModelProtocol) {
@@ -372,6 +369,7 @@ class ChatMessage: ALKChatViewModelProtocol {
         self.channelKey = message.channelKey
         self.conversationId = message.conversationId
         self.createdAt = message.createdAt
+        self.messageType = message.messageType
         // Update message to show conversation assignee details
         guard
             isGroupChat,


### PR DESCRIPTION
- This PR will show conversation assignee details (name and image) in conversation list screen.
- It is based on https://github.com/AppLozic/ApplozicSwift/pull/157
- Tested on device. 