### PR TITLE
Handle the case when parent VC is not part of a nav controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+1.2.1(Upcoming release)
+
+### Enhancments
+
+- Now if the parent VC(from where the conversation is shown) doesn't have a navigation controller then the Conversation VC will still be shown.
+
 1.2.0
 
 ### Enhancements

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
   - iOSSnapshotTestCase/SwiftSupport (4.0.1):
     - iOSSnapshotTestCase/Core
   - Kingfisher (4.7.0)
-  - Kommunicate (1.1.0):
+  - Kommunicate (1.2.0):
     - ApplozicSwift (~> 2.3.0)
   - MGSwipeTableCell (1.5.6)
   - Nimble (7.3.1)
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: f3b2b7e606fe03fdbe49af84316bd235df32dc44
   Kingfisher: da6b005aa96d37698e3e4f1ccfe96a5b9bbf27d6
-  Kommunicate: d9d89f54b8187bba339120b17d3a76ddd2971f53
+  Kommunicate: 76a09fe0c4a009da84f2f1195ff376d427ff1179
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Nimble-Snapshots: 79394f8d0aea3df54bd5ff78ee9dff05a523a09c

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -148,6 +148,9 @@ extension KMConversationViewController: NavigationBarCallbacks {
     func backButtonPressed() {
         guard let channelId = viewModel.channelKey else { return }
         sendConversationCloseNotification(channelId: String(describing: channelId))
-        self.navigationController?.popViewController(animated: true)
+        let popVC = self.navigationController?.popViewController(animated: true)
+        if popVC == nil {
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 }

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -218,8 +218,12 @@ open class Kommunicate: NSObject {
             conversationViewController.title = channel.name
             conversationViewController.viewModel = convViewModel
             conversationViewController.kmConversationViewConfiguration = kmConversationViewConfiguration
-            viewController.navigationController?
-                .pushViewController(conversationViewController, animated: false)
+            if let navigationVC = viewController.navigationController {
+                navigationVC.pushViewController(conversationViewController, animated: false)
+            } else {
+                let navigationController = UINavigationController(rootViewController: conversationViewController)
+                viewController.present(navigationController, animated: false, completion: nil)
+            }
             completionHandler(true)
         }
     }


### PR DESCRIPTION
After this PR if the parent VC doesn't have a navigation controller then the Conversation VC will still be shown.