### PR TITLE
[AL-3393] Pass send message metadata in create group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+1.4.0(Upcoming release)
+
+### Enhancments
+
+- [AL-3393] Added support for passing send message metadata in create group.
+
 1.3.0
 
 ### Enhancments

--- a/Kommunicate/Classes/KMConversationService.swift
+++ b/Kommunicate/Classes/KMConversationService.swift
@@ -43,6 +43,28 @@ public class KMConversationService: KMConservationServiceable {
         case messageNotPresent
     }
 
+    let groupMetadata: NSMutableDictionary = {
+        let metadata = NSMutableDictionary()
+        metadata.setValue("", forKey: AL_CREATE_GROUP_MESSAGE)
+        metadata.setValue("", forKey: AL_REMOVE_MEMBER_MESSAGE)
+        metadata.setValue("", forKey: AL_ADD_MEMBER_MESSAGE)
+        metadata.setValue("", forKey: AL_JOIN_MEMBER_MESSAGE)
+        metadata.setValue("", forKey: AL_GROUP_NAME_CHANGE_MESSAGE)
+        metadata.setValue("", forKey: AL_GROUP_ICON_CHANGE_MESSAGE)
+        metadata.setValue("", forKey: AL_GROUP_LEFT_MESSAGE)
+        metadata.setValue("", forKey: AL_DELETED_GROUP_MESSAGE)
+        metadata.setValue("true", forKey: "HIDE")
+        metadata.setValue("false", forKey: "ALERT")
+
+        // Required for features like setting user language in server.
+        guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,
+            !messageMetadata.isEmpty else {
+                return metadata
+        }
+        metadata.addEntries(from: messageMetadata)
+        return metadata
+    }()
+
     //MARK: - Initialization
 
     public init() { }
@@ -249,21 +271,6 @@ public class KMConversationService: KMConservationServiceable {
         return agentIds.map { createAgentGroupUserFrom(agentId: $0) }
     }
 
-    private func getGroupMetadata() -> NSMutableDictionary {
-        let metadata = NSMutableDictionary()
-        metadata.setValue("", forKey: AL_CREATE_GROUP_MESSAGE)
-        metadata.setValue("", forKey: AL_REMOVE_MEMBER_MESSAGE)
-        metadata.setValue("", forKey: AL_ADD_MEMBER_MESSAGE)
-        metadata.setValue("", forKey: AL_JOIN_MEMBER_MESSAGE)
-        metadata.setValue("", forKey: AL_GROUP_NAME_CHANGE_MESSAGE)
-        metadata.setValue("", forKey: AL_GROUP_ICON_CHANGE_MESSAGE)
-        metadata.setValue("", forKey: AL_GROUP_LEFT_MESSAGE)
-        metadata.setValue("", forKey: AL_DELETED_GROUP_MESSAGE)
-        metadata.setValue("true", forKey: "HIDE")
-        metadata.setValue("false", forKey: "ALERT")
-        return metadata
-    }
-
     private func isGroupPresent(clientId: String, completion:@escaping (_ isPresent: Bool)->()){
         let client = ALChannelService()
         client.getChannelInformation(byResponse: nil, orClientChannelKey: clientId, withCompletion: {
@@ -294,7 +301,6 @@ public class KMConversationService: KMConservationServiceable {
         }
         let alChannelService = ALChannelService()
         let groupUsers = members.map { $0.toDict() }
-        let metadata = getGroupMetadata()
 
         alChannelService.createChannel(
             groupName,
@@ -302,7 +308,7 @@ public class KMConversationService: KMConservationServiceable {
             andMembersList: membersList,
             andImageLink: nil,
             channelType: 10,
-            andMetaData: metadata,
+            andMetaData: groupMetadata,
             adminUser: agentIds.first,
             withGroupUsers: NSMutableArray(array: groupUsers),
             withCompletion: {

--- a/Kommunicate/Classes/KMConversationService.swift
+++ b/Kommunicate/Classes/KMConversationService.swift
@@ -44,17 +44,8 @@ public class KMConversationService: KMConservationServiceable {
     }
 
     let groupMetadata: NSMutableDictionary = {
-        let metadata = NSMutableDictionary()
-        metadata.setValue("", forKey: AL_CREATE_GROUP_MESSAGE)
-        metadata.setValue("", forKey: AL_REMOVE_MEMBER_MESSAGE)
-        metadata.setValue("", forKey: AL_ADD_MEMBER_MESSAGE)
-        metadata.setValue("", forKey: AL_JOIN_MEMBER_MESSAGE)
-        metadata.setValue("", forKey: AL_GROUP_NAME_CHANGE_MESSAGE)
-        metadata.setValue("", forKey: AL_GROUP_ICON_CHANGE_MESSAGE)
-        metadata.setValue("", forKey: AL_GROUP_LEFT_MESSAGE)
-        metadata.setValue("", forKey: AL_DELETED_GROUP_MESSAGE)
-        metadata.setValue("true", forKey: "HIDE")
-        metadata.setValue("false", forKey: "ALERT")
+        let metadata = NSMutableDictionary(
+            dictionary: ALChannelService().metadataToHideActionMessagesAndTurnOffNotifications())
 
         // Required for features like setting user language in server.
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,


### PR DESCRIPTION
We already pass the metadata while sending a message now it will also be passed in create group call.
Adding it here as it's only required in Kommunicate.

Tested it with a couple of examples, works fine. Tried different key-value combinations.