### PR TITLE
[AL-3493] Podspec: Add strings file in resources

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 2d51aa06775e95cecb0a1fb9c5c159ccd1dd4596
   Kingfisher: da6b005aa96d37698e3e4f1ccfe96a5b9bbf27d6
-  Kommunicate: 819ad155504265a96ebca834e1180c52e20bebcb
+  Kommunicate: 1e5947b422f0b4b2c0c7d4a4e8ad47dd85913286
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Nimble-Snapshots: bbd1ab264bacc24a9ce24a8363bc05aac783aeb0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Applozic (6.9.0):
     - SDWebImage (~> 4.4)
-  - ApplozicSwift (2.5.0):
+  - ApplozicSwift (2.5.1):
     - Applozic (~> 6.9.0)
     - Kingfisher (~> 4.7.0)
     - MGSwipeTableCell (~> 1.5.6)
@@ -17,7 +17,7 @@ PODS:
     - iOSSnapshotTestCase/Core
   - Kingfisher (4.7.0)
   - Kommunicate (1.4.0):
-    - ApplozicSwift (~> 2.5.0)
+    - ApplozicSwift (~> 2.5.1)
   - MGSwipeTableCell (1.5.6)
   - Nimble (7.3.4)
   - Nimble-Snapshots (6.9.1):
@@ -56,11 +56,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Applozic: e7ca1b4c8b981562d60ab412f2b5b821c213ed09
-  ApplozicSwift: aa14e9b613e05ec062aaf9562fb1b3ccd8c9c497
+  ApplozicSwift: 043bdd3fb0f5153159c458ef86b4a2210c2e233d
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 2d51aa06775e95cecb0a1fb9c5c159ccd1dd4596
   Kingfisher: da6b005aa96d37698e3e4f1ccfe96a5b9bbf27d6
-  Kommunicate: 1e5947b422f0b4b2c0c7d4a4e8ad47dd85913286
+  Kommunicate: a35319dda39bfa46674466e1bd122cff90c36828
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Nimble-Snapshots: bbd1ab264bacc24a9ce24a8363bc05aac783aeb0

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.swift_version = '4.2'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
-  s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json}'
+  s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json,strings}'
   s.dependency 'ApplozicSwift', '~> 2.5.0'
 end

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.swift_version = '4.2'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json,strings}'
-  s.dependency 'ApplozicSwift', '~> 2.5.0'
+  s.dependency 'ApplozicSwift', '~> 2.5.1'
 end


### PR DESCRIPTION
This will fix an issue where the framework localization file was not part of the pod. Also, updated ApplozicSwift to 2.5.1 which contains some bug fixes.

Tried adding Kommunicate in a sample app and localization file is present.