### PR TITLE
[AL-3482]Accept clientConversationId in createConversation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+1.6.0
+---
+### Enhancments
+- [AL-3482] Now in `createConversation` API, clientConversationId can be passed. You can use this Id if you want to link a conversation with some event on your side.
+
 1.5.0
 ---
 ### Enhancements

--- a/Example/Tests/KommunicateTests.swift
+++ b/Example/Tests/KommunicateTests.swift
@@ -23,6 +23,7 @@ class KommunicateTests: XCTestCase {
             agentIds: [String],
             botIds: [String]?,
             useLastConversation: Bool = false,
+            clientConversationId: String?,
             completion:@escaping (_ clientGroupId: String) -> ()) {
 
             createConversationsCalled = true


### PR DESCRIPTION
Added a new param `clientConversationId` in `createConversation` API which will accept the client Id that will be associated with this conversation and the same will be used to fetch the conversation.

Also, renamed(and deprecated) `createConversation` method in `KMConversationService` class.

Tried creating multiple conversations locally and fetched some, seems to be working fine.