### PR TITLE
Fix warnings and update dependencies #trivial

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - Applozic (6.17.1):
     - SDWebImage (~> 5.1.0)
-  - ApplozicSwift (4.0.0):
-    - ApplozicSwift/Complete (= 4.0.0)
-  - ApplozicSwift/Complete (4.0.0):
+  - ApplozicSwift (4.0.1):
+    - ApplozicSwift/Complete (= 4.0.1)
+  - ApplozicSwift/Complete (4.0.1):
     - Applozic (~> 6.17.0)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.7.0)
     - MGSwipeTableCell (~> 1.6.9)
-  - ApplozicSwift/RichMessageKit (4.0.0)
+  - ApplozicSwift/RichMessageKit (4.0.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
@@ -42,16 +42,17 @@ DEPENDENCIES:
   - Quick
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
-    - Applozic
-    - ApplozicSwift
+  https://github.com/CocoaPods/Specs.git:
     - FBSnapshotTestCase
     - iOSSnapshotTestCase
-    - Kingfisher
-    - MGSwipeTableCell
     - Nimble
     - Nimble-Snapshots
     - Quick
+  trunk:
+    - Applozic
+    - ApplozicSwift
+    - Kingfisher
+    - MGSwipeTableCell
     - SDWebImage
 
 EXTERNAL SOURCES:
@@ -60,7 +61,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Applozic: 222715a22ca0f8048390067ad3e44e80c78d096d
-  ApplozicSwift: b7d470f3e9f13ceb6ab4dd91286d07c524f3f8ff
+  ApplozicSwift: 75effb6ac41c4792912acca935b4990b473adc6f
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 2d51aa06775e95cecb0a1fb9c5c159ccd1dd4596
   Kingfisher: 176d377ad339113c99ad4980cbae687f807e20fe
@@ -73,4 +74,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 082b42a1ee8e13768ec8ed01a094d7959ec3a111
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/Example/Tests/ConversationVCNavBarSnapshotTests.swift
+++ b/Example/Tests/ConversationVCNavBarSnapshotTests.swift
@@ -40,7 +40,6 @@ class ConversationVCNavBarSnapshotTests: QuickSpec, NavigationBarCallbacks {
             
             beforeEach {
                 customNavigationView = ConversationVCNavBar(
-                    navigationBarBackgroundColor: UIColor(236, green: 239, blue: 241),
                     delegate: self,
                     localizationFileName: "Localizable",
                     configuration: KMConversationViewConfiguration())
@@ -72,6 +71,7 @@ class ConversationVCNavBarSnapshotTests: QuickSpec, NavigationBarCallbacks {
     func applyColor(navigationController : UINavigationController) {
         navigationController.navigationBar.isTranslucent = false
         navigationController.navigationBar.tintColor = UIColor.red
+        navigationController.navigationBar.barTintColor = UIColor(236, green: 239, blue: 241)
         navigationController.navigationBar.titleTextAttributes = [
             .foregroundColor: UIColor.blue,
             .font: UIFont.boldSystemFont(ofSize: 16),

--- a/Kommunicate/Assets/KMPreChatUserFormView.xib
+++ b/Kommunicate/Assets/KMPreChatUserFormView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -32,7 +30,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="5K0-aw-Fs0">
-                    <rect key="frame" x="15" y="106" width="345" height="502"/>
+                    <rect key="frame" x="15" y="86" width="345" height="502"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="siq-d0-j4b">
                             <rect key="frame" x="35" y="0.0" width="275.5" height="142"/>
@@ -182,7 +180,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SM4-Ob-Uc2">
                             <rect key="frame" x="0.0" y="426" width="345" height="76"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WpO-nN-HX8">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WpO-nN-HX8">
                                     <rect key="frame" x="0.0" y="0.0" width="345" height="40"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="40" id="lWF-bt-dxh"/>

--- a/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -10,7 +10,7 @@ import Applozic
 import ApplozicSwift
 import Kingfisher
 
-protocol NavigationBarCallbacks {
+protocol NavigationBarCallbacks: AnyObject {
     func backButtonPressed()
 }
 
@@ -21,10 +21,9 @@ extension NSAttributedString.Key {
 }
 
 class ConversationVCNavBar: UIView, Localizable {
-    
-    var navigationBarBackgroundColor: UIColor
+
     var configuration: KMConversationViewConfiguration!
-    var delegate: NavigationBarCallbacks!
+    weak var delegate: NavigationBarCallbacks?
     var localizationFileName: String!
     
     let backButton: UIButton = {
@@ -53,7 +52,6 @@ class ConversationVCNavBar: UIView, Localizable {
     
     lazy var statusIconBackgroundColor: UIView = {
         let view = UIView()
-        view.backgroundColor = self.navigationBarBackgroundColor
         view.layer.cornerRadius = 6
         view.clipsToBounds = true
         return view
@@ -91,11 +89,9 @@ class ConversationVCNavBar: UIView, Localizable {
     }
     
     required init(
-        navigationBarBackgroundColor: UIColor,
         delegate: NavigationBarCallbacks,
         localizationFileName: String,
         configuration: KMConversationViewConfiguration) {
-        self.navigationBarBackgroundColor = navigationBarBackgroundColor
         self.configuration = configuration
         self.delegate = delegate
         self.localizationFileName = localizationFileName
@@ -116,7 +112,7 @@ class ConversationVCNavBar: UIView, Localizable {
     }
     
     @objc func backButtonClicked(_ sender: UIButton) {
-        delegate.backButtonPressed()
+        delegate?.backButtonPressed()
     }
 
     func setupAppearance(_ appearance: UINavigationBar) {
@@ -133,6 +129,7 @@ class ConversationVCNavBar: UIView, Localizable {
         if let tintColor = appearance.tintColor {
             backButton.tintColor = tintColor
         }
+        statusIconBackgroundColor.backgroundColor = appearance.barTintColor
     }
 
     private func setupConstraints() {

--- a/Kommunicate/Classes/FaqViewController.swift
+++ b/Kommunicate/Classes/FaqViewController.swift
@@ -40,8 +40,6 @@ public class FaqViewController: UIViewController, Localizable {
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        guard let navigationController = navigationController else { return }
-        configureNavigationBar(navigationController.navigationBar)
         var backImage = UIImage.init(named: "icon_back", in: Bundle.kommunicate, compatibleWith: nil)
         backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
         navigationItem.leftBarButtonItem = UIBarButtonItem.init(image: backImage, style: .plain, target: self , action: #selector(backTapped))
@@ -51,14 +49,6 @@ public class FaqViewController: UIViewController, Localizable {
     @objc func backTapped() {
         self.dismiss(animated: true, completion: nil)
     }
-
-    private func configureNavigationBar(_ navigationBar: UINavigationBar) {
-        navigationBar.barTintColor = configuration.navigationBarBackgroundColor
-        navigationBar.tintColor = configuration.navigationBarItemColor
-        navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: configuration.navigationBarTitleColor]
-        navigationBar.isTranslucent = false
-    }
-
 }
 
 extension FaqViewController: WKNavigationDelegate {

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -17,7 +17,6 @@ open class KMConversationViewController: ALKConversationViewController {
     public var kmConversationViewConfiguration: KMConversationViewConfiguration!
 
     lazy var customNavigationView = ConversationVCNavBar(
-        navigationBarBackgroundColor: self.configuration.navigationBarBackgroundColor,
         delegate: self,
         localizationFileName: self.configuration.localizedStringFileName,
         configuration: kmConversationViewConfiguration)


### PR DESCRIPTION
- Fixed warnings due to usage of deprecated APIs.
- Removed `navigationBarBackgroundColor` property from`ConversationVCNavBar` and changed delegate to `weak`. As we update the navigation bar colors in `setupAppearance(_ appearance: UINavigationBar)` using `UINavigationBar`.
- Updated ApplozicSwift and CocoaPods.
- All tests are passing.