### PR TITLE
[CM-122] Update Rating scale and submission response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Fixes
+
+- [CM-122] Updated CSAT rating scale to 1-10 from 1-3.
+
 ## [3.1.0] - 2020-01-28
 
 ### Enhancements

--- a/Kommunicate/Classes/Extensions/KMConversationService+ConversationFeedback.swift
+++ b/Kommunicate/Classes/Extensions/KMConversationService+ConversationFeedback.swift
@@ -74,9 +74,10 @@ extension KMConversationService {
         DataLoader.postRequest(url: url, params: params) { result in
             switch result {
             case .success(let data):
-                guard let feedbackResponse = try? ConversationFeedbackResponse(data: data) else {
-                    completion(.failure(.api(.jsonConversion)))
-                    return
+                guard let feedbackResponse =
+                    try? ConversationFeedbackSubmissionResponse(data: data) else {
+                        completion(.failure(.api(.jsonConversion)))
+                        return
                 }
                 do {
                     let feedback = try feedbackResponse.conversationFeedback()
@@ -90,17 +91,5 @@ extension KMConversationService {
                 completion(.failure(.api(.network(error))))
             }
         }
-    }
-}
-
-extension ConversationFeedbackResponse {
-    func conversationFeedback() throws -> ConversationFeedback {
-        guard code == "SUCCESS" else {
-            throw FeedbackError.invalidCodeValue
-        }
-        guard let feedback = data else {
-            throw FeedbackError.notFound
-        }
-        return feedback
     }
 }

--- a/Kommunicate/Classes/Models/ConversationFeedback.swift
+++ b/Kommunicate/Classes/Models/ConversationFeedback.swift
@@ -7,14 +7,37 @@
 
 import Foundation
 
+// MARK: - FeedbackResponse
+protocol FeedbackResponse {
+    var code: String { get }
+    var data: ConversationFeedback? { get }
+
+    func conversationFeedback() throws -> ConversationFeedback
+}
+
 // MARK: - ConversationFeedbackResponse
-struct ConversationFeedbackResponse: Codable {
+struct ConversationFeedbackResponse: Decodable, FeedbackResponse {
     let code: String
     let data: ConversationFeedback?
 }
 
+// MARK: - ConversationFeedbackSubmissionResponse
+struct ConversationFeedbackSubmissionResponse: FeedbackResponse {
+    let code: String
+    let data: ConversationFeedback?
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case data
+    }
+
+    enum FeedbackResponseKeys: String, CodingKey {
+        case data
+    }
+}
+
 // MARK: - ConversationFeedback
-struct ConversationFeedback: Codable {
+struct ConversationFeedback: Decodable {
     let id, groupID: Int
     let comments: [String]?
     let rating: Int
@@ -46,5 +69,33 @@ enum FeedbackError: LocalizedError {
 extension ConversationFeedbackResponse {
     init(data: Data) throws {
         self = try JSONDecoder().decode(ConversationFeedbackResponse.self, from: data)
+    }
+}
+
+extension ConversationFeedbackSubmissionResponse: Decodable {
+    init(data: Data) throws {
+        self = try JSONDecoder().decode(ConversationFeedbackSubmissionResponse.self, from: data)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        code = try values.decode(String.self, forKey: .code)
+        let feedbackResponse = try values.nestedContainer(
+            keyedBy: FeedbackResponseKeys.self,
+            forKey: .data
+        )
+        data = try feedbackResponse.decode(ConversationFeedback.self, forKey: .data)
+    }
+}
+
+extension FeedbackResponse {
+    func conversationFeedback() throws -> ConversationFeedback {
+        guard code == "SUCCESS" else {
+            throw FeedbackError.invalidCodeValue
+        }
+        guard let feedback = data else {
+            throw FeedbackError.notFound
+        }
+        return feedback
     }
 }

--- a/Kommunicate/Classes/Views/FeedbackRatingView.swift
+++ b/Kommunicate/Classes/Views/FeedbackRatingView.swift
@@ -54,7 +54,7 @@ class FeedbackRatingView: UIView {
             guard allTags.contains(selectedRatingTag) && selectedRatingTag != oldValue else { return }
             // update state of all buttons
             ratingButtons.forEach { $0.isInactive = ($0.tag != selectedRatingTag) }
-            ratingSelected?(RatingType(rawValue: tag) ?? .happy)
+            ratingSelected?(RatingType(rawValue: selectedRatingTag) ?? .happy)
         }
     }
 

--- a/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Kommunicate/Classes/Views/RatingViewController.swift
@@ -9,8 +9,8 @@ import Foundation
 
 enum RatingType: Int, CaseIterable {
     case sad = 1
-    case confused = 2
-    case happy = 3
+    case confused = 5
+    case happy = 10
 }
 
 struct Feedback {


### PR DESCRIPTION
- Changed ratings to `1, 5, 10` from `1, 2, 3`. This was done to match the new rating values in other platforms.
- Created a new model `ConversationFeedbackSubmissionResponse`, for feedback submission response. 
- These three cases are working fine in the sample app:
   - When feedback is available.
   - No feedback (but the state is closed).
   - After feedback (from iOS) is submitted.
- Enable CSAT to try this feature:
```
Kommunicate.kmConversationViewConfiguration.isCSATOptionDisabled = false
```