### PR TITLE
[CM-66] Add conversation restart feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 - Added way to set the conversation assignee during the conversation create.
 - App ID sanity check: If an empty App ID is passed or if it is changed later, the app will be stopped in the debug mode.
+- Added restart conversation option. If the conversation is closed, then the input text field will be disabled, and a restart button will be shown.
 
 ### Fixes
 - [CM-122] Updated CSAT rating scale to 1-10 from 1-3.

--- a/Kommunicate/Assets/Localizable.strings
+++ b/Kommunicate/Assets/Localizable.strings
@@ -49,6 +49,8 @@ NoName = "No Name";
 
 /* Closed Conversation */
 
+/* Conversation resolved label in restart conversation view */
+ConversationClosedDescription = "This conversation has been marked resolved";
 /* Restart conversation label */
 ConversationClosedOtherQueries = "Have other queries?";
 /* Restart conversation Button title */

--- a/Kommunicate/Assets/Localizable.strings
+++ b/Kommunicate/Assets/Localizable.strings
@@ -47,6 +47,13 @@ SupportChannelName = "Support";
 /* No name text */
 NoName = "No Name";
 
+/* Closed Conversation */
+
+/* Restart conversation label */
+ConversationClosedOtherQueries = "Have other queries?";
+/* Restart conversation Button title */
+ConversationClosedRestartConversation = "Restart conversation";
+
 /* CSAT Rating */
 
 /* Main title */
@@ -55,8 +62,6 @@ ConversationRatingTitle = "Rate the conversation";
 ConversationRatingCommentsPlaceholder = "Add a comment...";
 /* Submit button title */
 ConversationRatingSubmitButtonTitle = "Submit your rating";
-/* Restart conversation label */
-ConversationRatingRestartConversation = "Have other queries?  Restart conversation";
 /* Poor rating label */
 ConversationRatingOptionPoor = "Poor";
 /* Average rating label */

--- a/Kommunicate/Classes/Extensions/Style+Color.swift
+++ b/Kommunicate/Classes/Extensions/Style+Color.swift
@@ -10,13 +10,23 @@ import Foundation
 extension Style {
     enum Color {
         enum Background: Int {
-            case mediumGray = 0xf0f0f0
+            case mediumGrey = 0xf0f0f0
+        }
+
+        enum Text: Int {
+            case warmGrey = 0x8b8888
+            case warmBlue = 0x5451e2
+            case brownishGreyTwo = 0x676767
         }
     }
 }
 
 extension UIColor {
     static func background(_ color: Style.Color.Background) -> UIColor {
+        return .init(netHex: color.rawValue)
+    }
+
+    static func text(_ color: Style.Color.Text) -> UIColor {
         return .init(netHex: color.rawValue)
     }
 }

--- a/Kommunicate/Classes/Extensions/Style+Color.swift
+++ b/Kommunicate/Classes/Extensions/Style+Color.swift
@@ -1,0 +1,22 @@
+//
+//  Style+Color.swift
+//  ApplozicSwift
+//
+//  Created by Mukesh on 17/02/20.
+//
+
+import Foundation
+
+extension Style {
+    enum Color {
+        enum Background: Int {
+            case mediumGray = 0xf0f0f0
+        }
+    }
+}
+
+extension UIColor {
+    static func background(_ color: Style.Color.Background) -> UIColor {
+        return .init(netHex: color.rawValue)
+    }
+}

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -214,6 +214,9 @@ open class KMConversationViewController: ALKConversationViewController {
     }
 
     private func setupConversationClosedView() {
+        conversationClosedView.restartTapped = {[weak self] in
+            self?.isClosedConversationViewHidden = true
+        }
         view.addViewsForAutolayout(views: [conversationClosedView])
         var bottomAnchor = view.bottomAnchor
         if #available(iOS 11, *) {

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -188,10 +188,15 @@ open class KMConversationViewController: ALKConversationViewController {
 
     private func setupConversationClosedView() {
         view.addViewsForAutolayout(views: [conversationClosedView])
+
+        var bottomAnchor = view.bottomAnchor
+        if #available(iOS 11, *) {
+            bottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
+        }
         NSLayoutConstraint.activate([
             conversationClosedView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             conversationClosedView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            conversationClosedView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            conversationClosedView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
     }
 

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -338,6 +338,7 @@ extension KMConversationViewController {
         conversationClosedView.isHidden = !flag
         var heightDiff: Double = 0
         if flag {
+            view.endEditing(true)
             var bottomInset: CGFloat = 0
             if #available(iOS 11.0, *) {
                 bottomInset = view.safeAreaInsets.bottom

--- a/Kommunicate/Classes/Views/AwayMessageView.swift
+++ b/Kommunicate/Classes/Views/AwayMessageView.swift
@@ -39,13 +39,13 @@ class AwayMessageView: UIView {
     private let dottedLayer: CAShapeLayer = {
         let shapeLayer = CAShapeLayer()
         shapeLayer.strokeColor =  UIColor(netHex: 0xbebbbb).cgColor
-        shapeLayer.lineWidth = 1
+        shapeLayer.lineWidth = 0
         shapeLayer.lineDashPattern = [5, 5]
         shapeLayer.path = CGMutablePath()
         return shapeLayer
     }()
     private let dottedLineViewHeight: CGFloat = 1.0
-    lazy private var dottedLineHeightAnchor = dottedLineView.heightAnchor.constraint(equalToConstant: dottedLineViewHeight)
+    lazy private var dottedLineHeightAnchor = dottedLineView.heightAnchor.constraint(equalToConstant: 0)
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Kommunicate/Classes/Views/ConversationClosedView.swift
+++ b/Kommunicate/Classes/Views/ConversationClosedView.swift
@@ -9,6 +9,64 @@ import UIKit
 
 class ConversationClosedView: UIView {
 
+    var restartTapped: (()->(Void))?
+
+    private let conversationResolvedLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.numberOfLines = 1
+        label.textColor = .text(.brownishGreyTwo)
+        label.font = Style.Font.normal(size: 15).font()
+        label.backgroundColor = .clear
+        label.text = LocalizedText.conversationResolved
+        return label
+    }()
+
+    private let otherQueriesLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.numberOfLines = 1
+        label.textColor = .text(.warmGrey)
+        label.font = Style.Font.normal(size: 15).font()
+        label.backgroundColor = .clear
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = LocalizedText.otherQueries
+        return label
+    }()
+
+    private let restartConversationButton: UIButton = {
+        let button = UIButton(frame: .zero)
+        button.titleLabel?.font = Style.Font.normal(size: 15).font()
+        button.backgroundColor = .clear
+        button.setTitleColor(.text(.warmBlue), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(LocalizedText.restartConversation, for: .normal)
+        return button
+    }()
+
+    private let restartConversationStackView: UIStackView = {
+        let sv = UIStackView(frame: .zero)
+        sv.axis = .horizontal
+        sv.distribution = .fill
+        sv.alignment = .center
+        sv.spacing = Size.RestartConversationView.spacing
+        return sv
+    }()
+
+    override var isHidden: Bool {
+        didSet {
+            guard oldValue != isHidden else { return }
+            self.invalidateIntrinsicContentSize()
+            self.superview?.setNeedsLayout()
+            self.superview?.layoutIfNeeded()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        return CGSize(
+            width: conversationResolvedLabel.intrinsicContentSize.width,
+            height: isHidden ? 0:Size.maxHeight
+        )
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
@@ -19,7 +77,84 @@ class ConversationClosedView: UIView {
         setupView()
     }
 
-    func setupView() {
-        self.backgroundColor = .background(.mediumGray)
+    private func setupView() {
+        self.backgroundColor = .background(.mediumGrey)
+        setupLayout()
+    }
+
+    private func setupLayout() {
+        restartConversationStackView.addArrangedSubview(otherQueriesLabel)
+        restartConversationStackView.addArrangedSubview(restartConversationButton)
+        addViewsForAutolayout(views: [
+            conversationResolvedLabel,
+            restartConversationStackView
+        ])
+
+        NSLayoutConstraint.activate([
+            conversationResolvedLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: leadingAnchor,
+                constant: Size.ConversationResolvedLabel.leading
+            ),
+            conversationResolvedLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: trailingAnchor,
+                constant: Size.ConversationResolvedLabel.trailing
+            ),
+            conversationResolvedLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            conversationResolvedLabel.bottomAnchor.constraint(
+                equalTo: restartConversationStackView.topAnchor,
+                constant: Size.ConversationResolvedLabel.bottom
+            ),
+            restartConversationStackView.leadingAnchor.constraint(
+                greaterThanOrEqualTo: leadingAnchor,
+                constant: Size.RestartConversationView.leading
+            ),
+            restartConversationStackView.trailingAnchor.constraint(
+                lessThanOrEqualTo: trailingAnchor,
+                constant: Size.RestartConversationView.trailing
+            ),
+            restartConversationStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            restartConversationStackView.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: Size.RestartConversationView.bottom
+            )
+        ])
+    }
+}
+
+extension ConversationClosedView: Localizable {
+    enum LocalizedText {
+        static private let filename = Kommunicate.defaultConfiguration.localizedStringFileName
+
+        static let conversationResolved = localizedString(
+            forKey: "ConversationClosedDescription",
+            fileName: filename
+        )
+        static let otherQueries = localizedString(
+            forKey: "ConversationClosedOtherQueries",
+            fileName: filename
+        )
+        static let restartConversation = localizedString(
+            forKey: "ConversationClosedRestartConversation",
+            fileName: filename
+        )
+    }
+}
+
+extension ConversationClosedView {
+    enum Size {
+        static let maxHeight: CGFloat = 85
+
+        enum ConversationResolvedLabel {
+            static let leading: CGFloat = 30
+            static let trailing: CGFloat = -30
+            static let bottom: CGFloat = -18
+        }
+
+        enum RestartConversationView {
+            static let leading: CGFloat = 30
+            static let trailing: CGFloat = -30
+            static let bottom: CGFloat = -5
+            static let spacing: CGFloat = 8
+        }
     }
 }

--- a/Kommunicate/Classes/Views/ConversationClosedView.swift
+++ b/Kommunicate/Classes/Views/ConversationClosedView.swift
@@ -1,0 +1,25 @@
+//
+//  ConversationClosedView.swift
+//  ApplozicSwift
+//
+//  Created by Mukesh on 17/02/20.
+//
+
+import UIKit
+
+class ConversationClosedView: UIView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    func setupView() {
+        self.backgroundColor = .background(.mediumGray)
+    }
+}

--- a/Kommunicate/Classes/Views/ConversationClosedView.swift
+++ b/Kommunicate/Classes/Views/ConversationClosedView.swift
@@ -78,6 +78,11 @@ class ConversationClosedView: UIView {
     }
 
     private func setupView() {
+        restartConversationButton.addTarget(
+            self,
+            action: #selector(restartConversationTapped),
+            for: .touchUpInside
+        )
         self.backgroundColor = .background(.mediumGrey)
         setupLayout()
     }
@@ -118,6 +123,10 @@ class ConversationClosedView: UIView {
                 constant: Size.RestartConversationView.bottom
             )
         ])
+    }
+
+    @objc func restartConversationTapped() {
+        restartTapped?()
     }
 }
 

--- a/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Kommunicate/Classes/Views/RatingViewController.swift
@@ -372,6 +372,6 @@ extension RatingViewController: Localizable {
         static let title = localizedString(forKey: "ConversationRatingTitle", fileName: filename)
         static let commentPlaceholder = localizedString(forKey: "ConversationRatingCommentsPlaceholder", fileName: filename)
         static let submit = localizedString(forKey: "ConversationRatingSubmitButtonTitle", fileName: filename)
-        static let restartConversation = localizedString(forKey: "ConversationRatingRestartConversation", fileName: filename)
+        static let restartConversation = localizedString(forKey: "ConversationClosedRestartConversation", fileName: filename)
     }
 }


### PR DESCRIPTION
If the status of a conversation is closed then the text field for the message will be disabled. And closed conversation view is shown at the top of this input field. This view will have the conversation restart option. If a user taps on this button then this view will be removed and the input field(ChatBar) will be shown again.

![Simulator Screen Shot - iPhone 11 - 2020-02-20 at 12 58 24](https://user-images.githubusercontent.com/5956714/74911730-34fe8b00-53e3-11ea-9224-6f6a1542f267.png)

Tested in a variety of scenarios, such as when all attachment options are disabled, the away message is displayed and the rating view is also visible.