### PR TITLE
[CM-120] Add sanity checks for empty and new App ID in the setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ### Enhancements
 - Added way to set the conversation assignee during the conversation create.
+- App ID sanity check: If an empty App ID is passed or if it is changed later, the app will be stopped in the debug mode.
 
 ### Fixes
 - [CM-122] Updated CSAT rating scale to 1-10 from 1-3.

--- a/Kommunicate/Classes/Extensions/KMUserDefaultHandler+Extension.swift
+++ b/Kommunicate/Classes/Extensions/KMUserDefaultHandler+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  KMUserDefaultHandler+Extension.swift
+//  Kommunicate
+//
+//  Created by Mukesh on 21/02/20.
+//
+
+import Foundation
+
+extension KMUserDefaultHandler {
+    static var isAppIdEmpty: Bool {
+        guard let currentAppId = KMUserDefaultHandler.getApplicationKey() else { return true }
+        return currentAppId.isEmpty
+    }
+
+    static var matchesCurrentAppId: (String) -> Bool = {
+        guard let currentAppId = KMUserDefaultHandler.getApplicationKey() else { return false }
+        return currentAppId == $0
+    }
+}

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -135,7 +135,7 @@ open class Kommunicate: NSObject,Localizable{
      - applicationId: App ID that needs to be set up.
      */
     @objc open class func setup(applicationId: String) {
-        guard !applicationId.isEmpty else {
+        guard !applicationId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             assertionFailure("Kommunicate App ID: Empty value passed")
             return
         }

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -127,12 +127,23 @@ open class Kommunicate: NSObject,Localizable{
 
 
     /**
-     Setup a application id which will be used for all the requests.
+     Setup an App ID. It will be used for all Kommunicate related requests.
+
+     - NOTE: If the App ID is modified then make sure to log out and log in.
 
      - Parameters:
-     - applicationId: Application id that needs to be set up.
+     - applicationId: App ID that needs to be set up.
      */
     @objc open class func setup(applicationId: String) {
+        guard !applicationId.isEmpty else {
+            assertionFailure("Kommunicate App ID: Empty value passed")
+            return
+        }
+        guard KMUserDefaultHandler.isAppIdEmpty ||
+            KMUserDefaultHandler.matchesCurrentAppId(applicationId) else {
+                assertionFailure("Kommunicate App ID changed: log out and log in again")
+                return
+        }
         self.applicationId = applicationId
         ALUserDefaultsHandler.setApplicationKey(applicationId)
         Kommunicate.shared.defaultChatViewSettings()
@@ -392,15 +403,6 @@ open class Kommunicate: NSObject,Localizable{
         }
     }
 
-    private class func isNilOrEmpty(_ string: NSString?) -> Bool {
-
-        switch string {
-        case .some(let nonNilString): return nonNilString.length == 0
-        default:return true
-
-        }
-    }
-
     private class func createAConversationAndLaunch(
         from viewController: UIViewController,
         completion:@escaping (_ error: KommunicateError?) -> ()) {
@@ -610,5 +612,4 @@ class ChatMessage: ALKChatViewModelProtocol,Localizable {
         self.groupName = alChannel.name ?? localizedString(forKey: KMLocalizationKey.noName, fileName: Kommunicate.defaultConfiguration.localizedStringFileName)
         self.avatarGroupImageUrl = alChannel.channelImageURL
     }
-
 }


### PR DESCRIPTION
- Added two new checks: When an empty App ID is passed, and when a new App ID is passed in the setup.
- In both the cases, `assertionFailure` has been added to stop the execution.
- In case of new App ID, they should delete the data through log out and log in again.
- Tested all three scenarios in the sample App.