### PR TITLE
[CM-236] Enable CSAT and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [CM-236] Enable CSAT by default.
+
 ## [5.0.0] - 2020-04-01
 
 ### Enhancements

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -273,10 +273,9 @@
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "Kommunicate" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {

--- a/Example/Kommunicate.xcodeproj/xcshareddata/xcschemes/Kommunicate-Example.xcscheme
+++ b/Example/Kommunicate.xcodeproj/xcshareddata/xcschemes/Kommunicate-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Kommunicate.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/Kommunicate.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>BuildSystemType</key>
-	<string>Original</string>
+	<string>Latest</string>
 	<key>PreviewsEnabled</key>
 	<false/>
 </dict>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - Applozic (7.3.0):
     - SDWebImage (~> 5.1.0)
-  - ApplozicSwift (5.2.0):
-    - ApplozicSwift/Complete (= 5.2.0)
-  - ApplozicSwift/Complete (5.2.0):
+  - ApplozicSwift (5.3.0):
+    - ApplozicSwift/Complete (= 5.3.0)
+  - ApplozicSwift/Complete (5.3.0):
     - Applozic (~> 7.3.0)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.13.0)
     - MGSwipeTableCell (~> 1.6.11)
-  - ApplozicSwift/RichMessageKit (5.2.0)
+  - ApplozicSwift/RichMessageKit (5.3.0)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
@@ -19,11 +19,11 @@ PODS:
   - iOSSnapshotTestCase/Core (6.2.0)
   - iOSSnapshotTestCase/SwiftSupport (6.2.0):
     - iOSSnapshotTestCase/Core
-  - Kingfisher (5.13.2):
-    - Kingfisher/Core (= 5.13.2)
-  - Kingfisher/Core (5.13.2)
-  - Kommunicate (5.0.0):
-    - ApplozicSwift (~> 5.2.0)
+  - Kingfisher (5.13.4):
+    - Kingfisher/Core (= 5.13.4)
+  - Kingfisher/Core (5.13.4)
+  - Kommunicate (4.0.0):
+    - ApplozicSwift (~> 5.3.0)
   - MGSwipeTableCell (1.6.11)
   - Nimble (8.0.5)
   - Nimble-Snapshots (8.1.1):
@@ -62,11 +62,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Applozic: 9fffca38afaf77ced5196619e00a4c67b074ecfc
-  ApplozicSwift: 0ddfca3ed35fa19a065e56e45405a95b55a61f56
+  ApplozicSwift: c40a0a1fa362550d53ffacd550c363ed9886c97d
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
-  Kingfisher: d342c8354c10c3d85a27d6d4c42c41285924b898
-  Kommunicate: 0cd5e6616ce36ad44d3e1bedf480136cb15d19e0
+  Kingfisher: d2279a7abece3c7f25a80cd2b7f363ca5cf3f44c
+  Kommunicate: d3dc15de46a9d6f7c490ef39c478a9992b6f36cd
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
   Nimble: 4ab1aeb9b45553c75b9687196b0fa0713170a332
   Nimble-Snapshots: 5058fb9b459e64371f54a0f8d9dde6f33db490a0

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.swift_version = '4.2'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json,strings}'
-  s.dependency 'ApplozicSwift', '~> 5.2.0'
+  s.dependency 'ApplozicSwift', '~> 5.3.0'
 end

--- a/Kommunicate/Classes/KMConversationViewConfiguration.swift
+++ b/Kommunicate/Classes/KMConversationViewConfiguration.swift
@@ -13,7 +13,7 @@ public struct KMConversationViewConfiguration {
     public var imageForBackButton: UIImage?
     public var conversationLaunchNotificationName = "ConversationLaunched"
     public var backButtonNotificationName = "ConversationClosed"
-    public var isCSATOptionDisabled: Bool = true
+    public var isCSATOptionDisabled: Bool = false
      /// Start new conversation icon in conversation list.
     public var startNewButtonIcon : UIImage? = UIImage(named: "icon_new_chat_red", in: Bundle.kommunicate, compatibleWith: nil)
 


### PR DESCRIPTION
- Enabled CSAT, so now feedback option will be shown by default if a conversation has been resolved.
- Updated ApplozicSwift to 5.3.0.
- Changed sample app's build system to the new one.
- Tested: CSAT feature is working fine.
