### PR TITLE
[CM-308] Conversation in not switch while we open conversation through notification 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Fixes
+- [CM-308] Conversation was not switched while we open conversation through notification in some cases.
+
 ## [5.3.0] - 2020-06-09
 
 ### Enhancements

--- a/Example/Tests/KMConversationViewControllerTests.swift
+++ b/Example/Tests/KMConversationViewControllerTests.swift
@@ -24,7 +24,7 @@ class KMConversationViewControllerTests: QuickSpec {
                 beforeEach {
                     conversationDetailMock = ConversationDetailMock()
                     viewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: Kommunicate.defaultConfiguration.localizedStringFileName)
-                    viewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: KMConversationViewConfiguration())
+                    viewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: KMConversationViewConfiguration(), individualLaunch: true)
                     viewController.viewModel = viewModel
                     viewController.conversationDetail = conversationDetailMock
                 }

--- a/Example/Tests/KMConversationViewControllerTests.swift
+++ b/Example/Tests/KMConversationViewControllerTests.swift
@@ -24,7 +24,7 @@ class KMConversationViewControllerTests: QuickSpec {
                 beforeEach {
                     conversationDetailMock = ConversationDetailMock()
                     viewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: Kommunicate.defaultConfiguration.localizedStringFileName)
-                    viewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: KMConversationViewConfiguration(), individualLaunch: true)
+                    viewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: KMConversationViewConfiguration())
                     viewController.viewModel = viewModel
                     viewController.conversationDetail = conversationDetailMock
                 }

--- a/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Kommunicate/Classes/KMConversationListViewController.swift
@@ -375,7 +375,7 @@ public class KMConversationListViewController : ALKBaseViewController, Localizab
 
         let viewController: KMConversationViewController!
         if conversationViewController == nil {
-            viewController = KMConversationViewController(configuration: configuration, conversationViewConfiguration: kmConversationViewConfiguration)
+            viewController = KMConversationViewController(configuration: configuration, conversationViewConfiguration: kmConversationViewConfiguration, individualLaunch: false)
             viewController.viewModel = conversationViewModel
         } else {
             viewController = conversationViewController
@@ -702,7 +702,7 @@ extension KMConversationListViewController: ALKConversationListTableViewDelegate
     public func tapped(_ chat: ALKChatViewModelProtocol, at index: Int) {
 
         let convViewModel = conversationViewModelType.init(contactId: chat.contactId, channelKey: chat.channelKey, localizedStringFileName: configuration.localizedStringFileName)
-        let viewController = conversationViewController ?? KMConversationViewController(configuration: configuration, conversationViewConfiguration: kmConversationViewConfiguration)
+        let viewController = conversationViewController ?? KMConversationViewController(configuration: configuration, conversationViewConfiguration: kmConversationViewConfiguration, individualLaunch: false)
         viewController.viewModel = convViewModel
         viewController.individualLaunch = false
         navigationController?.pushViewController(viewController, animated: false)

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -67,7 +67,9 @@ open class KMConversationViewController: ALKConversationViewController {
         setupNavigation()
     }
 
-    required public init(configuration: ALKConfiguration, conversationViewConfiguration: KMConversationViewConfiguration ,individualLaunch : Bool) {
+    required public init(configuration: ALKConfiguration,
+                         conversationViewConfiguration: KMConversationViewConfiguration,
+                         individualLaunch : Bool = true) {
         self.kmConversationViewConfiguration = conversationViewConfiguration
         super.init(configuration: configuration)
         self.individualLaunch = individualLaunch

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -67,9 +67,10 @@ open class KMConversationViewController: ALKConversationViewController {
         setupNavigation()
     }
 
-    required public init(configuration: ALKConfiguration, conversationViewConfiguration: KMConversationViewConfiguration) {
+    required public init(configuration: ALKConfiguration, conversationViewConfiguration: KMConversationViewConfiguration ,individualLaunch : Bool) {
         self.kmConversationViewConfiguration = conversationViewConfiguration
         super.init(configuration: configuration)
+        self.individualLaunch = individualLaunch
         addNotificationCenterObserver()
     }
 
@@ -127,14 +128,14 @@ open class KMConversationViewController: ALKConversationViewController {
             object: nil,
             queue: nil,
             using: { [weak self] notification in
-            guard let notificationInfo = notification.userInfo,
-                let strongSelf = self else {
-                    return
-            }
-            let identifier = notificationInfo["identifier"] as? Int
-            if identifier == strongSelf.faqIdentifier{
-                Kommunicate.openFaq(from: strongSelf, with: strongSelf.configuration)
-            }
+                guard let notificationInfo = notification.userInfo,
+                    let strongSelf = self else {
+                        return
+                }
+                let identifier = notificationInfo["identifier"] as? Int
+                if identifier == strongSelf.faqIdentifier{
+                    Kommunicate.openFaq(from: strongSelf, with: strongSelf.configuration)
+                }
         })
 
         channelMetadataUpdateToken = NotificationCenter.default.observe(
@@ -144,6 +145,29 @@ open class KMConversationViewController: ALKConversationViewController {
             using: { [weak self] notification in
                 self?.onChannelMetadataUpdate()
         })
+
+        if individualLaunch {
+            NotificationCenter.default.addObserver(self, selector: #selector(pushNotification(notification:)), name: Notification.Name.pushNotification, object: nil)
+        }
+    }
+
+    @objc func pushNotification(notification: NSNotification) {
+        print("Push notification received in KMConversationViewController: ", notification.object ?? "")
+        let pushNotificationHelper = KMPushNotificationHelper(configuration, kmConversationViewConfiguration)
+        let (notifData, _) = pushNotificationHelper.notificationInfo(notification as Notification)
+        guard
+            self.isViewLoaded,
+            self.view.window != nil,
+            let notificationData = notifData,
+            !pushNotificationHelper.isNotificationForActiveThread(notificationData)
+            else { return }
+
+        unsubscribingChannel()
+        viewModel.contactId = nil
+        viewModel.channelKey = notificationData.groupId
+        viewModel.conversationProxy = nil
+        viewWillLoadFromTappingOnNotification()
+        refreshViewController()
     }
 
     func addAwayMessageConstraints() {

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -359,14 +359,14 @@ open class Kommunicate: NSObject,Localizable{
             cell.update(viewModel: message, identity: nil, disableSwipe: Kommunicate.defaultConfiguration.disableSwipeInChatCell)
             cell.chatCellDelegate = vc.conversationListTableViewController.self
         }
-        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
+        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration, individualLaunch: false)
         conversationViewController.viewModel = ALKConversationViewModel(contactId: nil, channelKey: nil, localizedStringFileName: defaultConfiguration.localizedStringFileName)
         vc.conversationViewController = conversationViewController
     }
 
     class func openChatWith(groupId: NSNumber, from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
         let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName)
-        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
+        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration, individualLaunch: true)
         conversationViewController.viewModel = convViewModel
         let navigationController = KMBaseNavigationViewController(rootViewController: conversationViewController)
         navigationController.modalPresentationStyle = .fullScreen

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -366,7 +366,7 @@ open class Kommunicate: NSObject,Localizable{
 
     class func openChatWith(groupId: NSNumber, from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
         let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName)
-        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration, individualLaunch: true)
+        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
         conversationViewController.viewModel = convViewModel
         let navigationController = KMBaseNavigationViewController(rootViewController: conversationViewController)
         navigationController.modalPresentationStyle = .fullScreen


### PR DESCRIPTION
* Fix the conversation was not switching

 **Description:** 
 In case the app is killed and open the conversation from notification,
 Keep the app in the background and send the message for a different conversation, 
In that case, the conversation was showing old launched conversation not the new 

* Added observer for push notification this will be triggered based on the  `individualLaunch` 

* Tried with killed state and switch between the conversation by sending a message from a different conversation works fine 
