### PR TITLE
Update ApplozicSwift to 5.7.1 #trivial

### DIFF
--- a/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
+++ b/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
@@ -41,6 +41,7 @@ class KommunicateCreateConversationAndSendMessagesTests: XCTestCase {
         let inputView = app.otherElements[AppScreen.chatBar].children(matching: .textView).matching(identifier: AppTextFeild.chatTextView).firstMatch
         waitFor(object: inputView) { $0.exists }
         inputView.tap()
+        sleep(3) // A temp fix till we add a check for loading
         inputView.typeText(GroupData.typeText) // typing message
         app.buttons[InAppButton.ConversationScreen.send].tap()
     }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Applozic (7.7.0):
+  - Applozic (7.8.0):
     - SDWebImage (~> 5.7.2)
-  - ApplozicSwift (5.7.0):
-    - ApplozicSwift/Complete (= 5.7.0)
-  - ApplozicSwift/Complete (5.7.0):
-    - Applozic (~> 7.7.0)
+  - ApplozicSwift (5.7.1):
+    - ApplozicSwift/Complete (= 5.7.1)
+  - ApplozicSwift/Complete (5.7.1):
+    - Applozic (~> 7.8.0)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.14.0)
     - MGSwipeTableCell (~> 1.6.11)
-  - ApplozicSwift/RichMessageKit (5.7.0)
+  - ApplozicSwift/RichMessageKit (5.7.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
@@ -19,11 +19,11 @@ PODS:
   - iOSSnapshotTestCase/Core (6.2.0)
   - iOSSnapshotTestCase/SwiftSupport (6.2.0):
     - iOSSnapshotTestCase/Core
-  - Kingfisher (5.14.0):
-    - Kingfisher/Core (= 5.14.0)
-  - Kingfisher/Core (5.14.0)
+  - Kingfisher (5.14.1):
+    - Kingfisher/Core (= 5.14.1)
+  - Kingfisher/Core (5.14.1)
   - Kommunicate (5.4.0):
-    - ApplozicSwift (~> 5.7.0)
+    - ApplozicSwift (~> 5.7.1)
   - MGSwipeTableCell (1.6.11)
   - Nimble (8.1.1)
   - Nimble-Snapshots (8.2.1):
@@ -61,12 +61,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Applozic: 055c1c646237644b6bac18efcb15214b85f243ff
-  ApplozicSwift: 1d1780d1e3870772f3ed5d9d0dbde9ea0d770bc8
+  Applozic: 7716e2dd8054dfcba2ca55f53ff6be3a9ae29190
+  ApplozicSwift: 34d7f69cc6fdc1868a2a1b90c17081776324097f
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
-  Kingfisher: 7b64389a43139c903ec434788344c288217c792d
-  Kommunicate: 9435f8aad4fdc407a4d9a146025718dc20d6f3b3
+  Kingfisher: 8050bc6f7f68cbf3908bd04df7ccbac188f6d6d6
+  Kommunicate: 5ff74a447ff9d0ea7ff451858fba6a25acf8f426
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
   Nimble: 5f8a2fb6fa343a7242dfdd9d42f7267419d464b2
   Nimble-Snapshots: 3a4750d83752625c8ebfdc588da105303ee2201e

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json,strings}'
-  s.dependency 'ApplozicSwift', '~> 5.7.0'
+  s.dependency 'ApplozicSwift', '~> 5.7.1'
 end


### PR DESCRIPTION
- Updated ApplozicSwift to 5.7.1 as it contains some fixes.
- Tested by sending text messages, and played audio messages to verify audio play fix.