### PR TITLE
Update ApplozicSwift to 5.8.0 #trivial

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Applozic (7.8.0):
+  - Applozic (7.8.2):
     - SDWebImage (~> 5.7.2)
-  - ApplozicSwift (5.7.1):
-    - ApplozicSwift/Complete (= 5.7.1)
-  - ApplozicSwift/Complete (5.7.1):
-    - Applozic (~> 7.8.0)
+  - ApplozicSwift (5.8.0):
+    - ApplozicSwift/Complete (= 5.8.0)
+  - ApplozicSwift/Complete (5.8.0):
+    - Applozic (~> 7.8.2)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.14.0)
     - MGSwipeTableCell (~> 1.6.11)
-  - ApplozicSwift/RichMessageKit (5.7.1)
+  - ApplozicSwift/RichMessageKit (5.8.0)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
@@ -23,7 +23,7 @@ PODS:
     - Kingfisher/Core (= 5.14.1)
   - Kingfisher/Core (5.14.1)
   - Kommunicate (5.4.1):
-    - ApplozicSwift (~> 5.7.1)
+    - ApplozicSwift (~> 5.8.0)
   - MGSwipeTableCell (1.6.11)
   - Nimble (8.1.1)
   - Nimble-Snapshots (8.2.1):
@@ -61,12 +61,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Applozic: 7716e2dd8054dfcba2ca55f53ff6be3a9ae29190
-  ApplozicSwift: 34d7f69cc6fdc1868a2a1b90c17081776324097f
+  Applozic: 41be9e6d1bb0516d270b684521a31ee00f1e52a2
+  ApplozicSwift: 0172028f846af6cc7cafa48f7b52b6b09fc9bb15
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Kingfisher: 8050bc6f7f68cbf3908bd04df7ccbac188f6d6d6
-  Kommunicate: d7bb9d86f2f365cefdd7f044fd4137c7f48f4076
+  Kommunicate: 21845ad7cfaa3e8ae3b7f805746f3b60fbd3596b
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
   Nimble: 5f8a2fb6fa343a7242dfdd9d42f7267419d464b2
   Nimble-Snapshots: 3a4750d83752625c8ebfdc588da105303ee2201e

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json,strings}'
-  s.dependency 'ApplozicSwift', '~> 5.7.1'
+  s.dependency 'ApplozicSwift', '~> 5.8.0'
 end


### PR DESCRIPTION
- Updated `ApplozicSwift` dependency to the latest version 5.8.0.
- All tests are passing.