### PR TITLE
Update ApplozicSwift to 5.8.1 #trivial

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Applozic (7.8.2):
+  - Applozic (7.8.3):
     - SDWebImage (~> 5.7.2)
-  - ApplozicSwift (5.8.0):
-    - ApplozicSwift/Complete (= 5.8.0)
-  - ApplozicSwift/Complete (5.8.0):
-    - Applozic (~> 7.8.2)
+  - ApplozicSwift (5.8.1):
+    - ApplozicSwift/Complete (= 5.8.1)
+  - ApplozicSwift/Complete (5.8.1):
+    - Applozic (~> 7.8.3)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.14.0)
     - MGSwipeTableCell (~> 1.6.11)
-  - ApplozicSwift/RichMessageKit (5.8.0)
+  - ApplozicSwift/RichMessageKit (5.8.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
@@ -23,7 +23,7 @@ PODS:
     - Kingfisher/Core (= 5.14.1)
   - Kingfisher/Core (5.14.1)
   - Kommunicate (5.5.0):
-    - ApplozicSwift (~> 5.8.0)
+    - ApplozicSwift (~> 5.8.1)
   - MGSwipeTableCell (1.6.11)
   - Nimble (8.1.1)
   - Nimble-Snapshots (8.2.1):
@@ -61,12 +61,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Applozic: 41be9e6d1bb0516d270b684521a31ee00f1e52a2
-  ApplozicSwift: 0172028f846af6cc7cafa48f7b52b6b09fc9bb15
+  Applozic: 437b0af932421eef09cbad558b2928bb80550c7e
+  ApplozicSwift: 91354fbaac4d38428a3fe83e16f3ed5492277419
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Kingfisher: 8050bc6f7f68cbf3908bd04df7ccbac188f6d6d6
-  Kommunicate: 33f5cd7a3aac00618114612a161677654c58c44a
+  Kommunicate: 733aed1915a1762c86a2c5bfd2aa70312324a149
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
   Nimble: 5f8a2fb6fa343a7242dfdd9d42f7267419d464b2
   Nimble-Snapshots: 3a4750d83752625c8ebfdc588da105303ee2201e

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.source_files = 'Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Kommunicate/Assets/**/*{lproj,storyboard,xib,xcassets,json,strings}'
-  s.dependency 'ApplozicSwift', '~> 5.8.0'
+  s.dependency 'ApplozicSwift', '~> 5.8.1'
 end


### PR DESCRIPTION
- Updated `ApplozicSwift` dependency to the latest version 5.8.1.
- All tests are passing.