### PR TITLE
[CM-327] Show agent's away status when an agent is in away mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+- [CM-327] Added support for showing Agent's away status.
+
 ## [5.4.0] - 2020-06-24
 
 ### Enhancements

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -496,6 +496,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Kommunicate_Tests/Pods-Kommunicate_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Applozic/Applozic.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
@@ -504,6 +506,8 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Applozic.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",

--- a/Example/Kommunicate/Base.lproj/Localizable.strings
+++ b/Example/Kommunicate/Base.lproj/Localizable.strings
@@ -34,6 +34,7 @@ PreChatViewGetStartedDescription = "We just need a few details to help you get s
 /* User's connection status */
 online = "Online";
 offline = "Offline";
+awayMode = "Away";
 
 /* Will be shown when the user's display name is not set */
 noName = "No Name";

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,6 +7,7 @@ target 'Kommunicate_Example' do
   target 'Kommunicate_Tests' do
     inherit! :search_paths
 
+    pod 'Applozic', :git => 'https://github.com/AppLozic/Applozic-Chat-iOS-Framework.git', :branch => 'contact-status'
     pod 'FBSnapshotTestCase' , '~> 2.1.4'
     pod 'Nimble'
     pod 'Quick'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -37,6 +37,7 @@ PODS:
   - SDWebImage/Core (5.7.4)
 
 DEPENDENCIES:
+  - Applozic (from `https://github.com/AppLozic/Applozic-Chat-iOS-Framework.git`, branch `contact-status`)
   - FBSnapshotTestCase (~> 2.1.4)
   - Kommunicate (from `../`)
   - Nimble
@@ -45,7 +46,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - Applozic
     - ApplozicSwift
     - FBSnapshotTestCase
     - iOSSnapshotTestCase
@@ -57,8 +57,16 @@ SPEC REPOS:
     - SDWebImage
 
 EXTERNAL SOURCES:
+  Applozic:
+    :branch: contact-status
+    :git: https://github.com/AppLozic/Applozic-Chat-iOS-Framework.git
   Kommunicate:
     :path: "../"
+
+CHECKOUT OPTIONS:
+  Applozic:
+    :commit: 76770807c658ef3bf29dbe488d0e4a5b620a8afc
+    :git: https://github.com/AppLozic/Applozic-Chat-iOS-Framework.git
 
 SPEC CHECKSUMS:
   Applozic: 437b0af932421eef09cbad558b2928bb80550c7e
@@ -73,6 +81,6 @@ SPEC CHECKSUMS:
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   SDWebImage: 48b88379b798fd1e4298f95bb25d2cdabbf4deb3
 
-PODFILE CHECKSUM: 5ab43809e48aca107f18f18476bb438b5b140ea1
+PODFILE CHECKSUM: 9f525e6902d1569c4028e12020841e102dcbfb7a
 
 COCOAPODS: 1.9.3

--- a/Kommunicate/Assets/Localizable.strings
+++ b/Kommunicate/Assets/Localizable.strings
@@ -34,6 +34,7 @@ PreChatViewGetStartedDescription = "We just need a few details to help you get s
 /* User's connection status */
 online = "Online";
 offline = "Offline";
+awayMode = "Away";
 
 /* Will be shown when the user's display name is not set */
 noName = "No Name";

--- a/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -82,9 +82,9 @@ class ConversationVCNavBar: UIView, Localizable {
     }()
 
     struct LocalizationKey {
-
         static let online = "online"
         static let offline = "offline"
+        static let awayMode = "awayMode"
         static let noName = "noName"
     }
     
@@ -218,10 +218,16 @@ class ConversationVCNavBar: UIView, Localizable {
     
     private func setupOnlineStatus(_ contact: ALContact?) {
         guard let alContact = contact else {
-            return;
+            return
         }
-        
         if (alContact.connected || alContact.roleType == 1) {
+            guard !alContact.isInAwayMode else {
+                onlineStatusText.text = localizedString(
+                    forKey: LocalizationKey.awayMode,
+                    fileName: localizationFileName)
+                onlineStatusIcon.backgroundColor = .background(.darkYellow)
+                return
+            }
             onlineStatusText.text = localizedString(
                 forKey: LocalizationKey.online,
                 fileName: localizationFileName)

--- a/Kommunicate/Classes/Extensions/ALContact+Extension.swift
+++ b/Kommunicate/Classes/Extensions/ALContact+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  ALContact+Extension.swift
+//  Kommunicate
+//
+//  Created by Mukesh on 27/07/20.
+//
+
+import Foundation
+import Applozic
+
+extension ALContact {
+    static let AwayMode: Int = 2
+
+    var isInAwayMode: Bool {
+        guard let status = status else { return false }
+        return status.intValue == ALContact.AwayMode
+    }
+}

--- a/Kommunicate/Classes/Extensions/Style+Color.swift
+++ b/Kommunicate/Classes/Extensions/Style+Color.swift
@@ -12,6 +12,7 @@ extension Style {
         enum Background: Int {
             case mediumGrey = 0xf0f0f0
             case lightGreyOne = 0xf9f9f9
+            case darkYellow = 0xD6A64D
         }
 
         enum Text: Int {


### PR DESCRIPTION
- Added support for showing Agent's away status in the conversation detail.
- If the conversation assignee(agent) is in away mode and connected, then Agent's status will be shown as "Away".
- Earlier only online and offline status of the agent was shown. Now, there are three possibilities.
- If the user is not connected(online), then the away mode won't be checked.
- Dependent on [contact status changes in Applozic](https://github.com/AppLozic/Applozic-iOS-SDK-Dev/pull/769).
- I've pointed to [contact-status](https://github.com/AppLozic/Applozic-Chat-iOS-Framework/tree/contact-status) branch of the Applozic pod repo for now.
- Check screenshots in the description of this [Jira issue](https://applozic.atlassian.net/browse/CM-327).