### PR TITLE
[CM-395] Create a single thread if it's enabled for the conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 - [CM-327] Added support for showing Agent's away status.
 ### Fixes
 - [CM-376] Use clientConversationId if present when single threaded option is enabled.
+- [CM-395] Fixed an issue where only dashboard settings for single threaded conversation was used.
 
 ## [5.4.0] - 2020-06-24
 

--- a/Kommunicate/Classes/KMConversation.swift
+++ b/Kommunicate/Classes/KMConversation.swift
@@ -67,7 +67,7 @@ import Applozic
 
     /// If you pass useLastConversation as false, then a new conversation will be created everytime. If you pass useLastConversation as true, then it will use old conversation which is already created with this data.
     /// - Parameter useLastConversation: Pass  useLastConversation
-    ///     @discardableResult
+    @discardableResult
     @objc public func useLastConversation(_ useLastConversation: Bool) ->  KMConversationBuilder {
         conversation.useLastConversation = useLastConversation
         return self

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -206,7 +206,6 @@ open class Kommunicate: NSObject,Localizable{
         if KMUserDefaultHandler.isLoggedIn() {
             var allAgentIds = conversation.agentIds
             var allBotIds = ["bot"] // Default bot that should be added everytime.
-
             if let botIds = conversation.botIds { allBotIds.append(contentsOf: botIds) }
 
             appSettingsService.appSetting {
@@ -214,8 +213,10 @@ open class Kommunicate: NSObject,Localizable{
                 switch result {
                 case .success(let appSettings):
                     allAgentIds.append(appSettings.agentID)
-
-                    if let chatWidget = appSettings.chatWidget,
+                    // If single threaded is not enabled for this conversation,
+                    // then check in global app settings.
+                    if !conversation.useLastConversation,
+                        let chatWidget = appSettings.chatWidget,
                         let isSingleThreaded = chatWidget.isSingleThreaded {
                         conversation.useLastConversation = isSingleThreaded
                     }


### PR DESCRIPTION
- Fixed an issue where only dashboard settings for single thread conversation was used.
- Now, if `useLastConversation` property of `KMConversation` is true, then dashboard settings won't be used.
- Tested by enabling and disabling single thread option in the dashboard and locally.