### PR TITLE
[CM-376] Use clientConversationId if present when single thread option is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ### Enhancements
 - [CM-327] Added support for showing Agent's away status.
+### Fixes
+- [CM-376] Use clientConversationId if present when single threaded option is enabled.
 
 ## [5.4.0] - 2020-06-24
 

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -219,23 +219,21 @@ open class Kommunicate: NSObject,Localizable{
                         let isSingleThreaded = chatWidget.isSingleThreaded {
                         conversation.useLastConversation = isSingleThreaded
                     }
-
                 case .failure(let error):
                     completion(.failure(KMConversationError.api(error)))
                     return
                 }
-
                 allAgentIds = allAgentIds.uniqueElements
                 conversation.agentIds = allAgentIds
                 conversation.botIds = allBotIds
 
-                if conversation.useLastConversation {
+                let isClientIdEmpty = (conversation.clientConversationId ?? "").isEmpty
+                if isClientIdEmpty && conversation.useLastConversation {
                     conversation.clientConversationId = service.createClientIdFrom(
                         userId: conversation.userId,
                         agentIds: conversation.agentIds,
                         botIds: conversation.botIds ?? [])
                 }
-
                 service.createConversation(conversation: conversation, completion: { response in
                     guard let conversationId = response.clientChannelKey else {
                         completion(.failure(KMConversationError.api(response.error)))


### PR DESCRIPTION
- Fixed an issue where `clientConversationId` was not used if single thread is option enabled for this conversation or through dashboard.
- If `clientConversationId` is present then a new id for the unique conversation won't be created.
- Tested by creating a new conversation with a particular conversation ID when single thread option was enabled.