### PR TITLE
[CM-375 ] Fixed if agentIds are passed in the conversation the default agentId was added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 - [CM-327] Added support for showing Agent's away status.
 ### Fixes
+
 - [CM-376] Use clientConversationId if present when single threaded option is enabled.
 - [CM-395] Fixed an issue where only dashboard settings for single threaded conversation was used.
+- [CM-375] Fixed issue if agentIds are passed in the conversation the default agentId was added.
 
 ## [5.4.0] - 2020-06-24
 

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -212,7 +212,10 @@ open class Kommunicate: NSObject,Localizable{
                 result in
                 switch result {
                 case .success(let appSettings):
-                    allAgentIds.append(appSettings.agentID)
+
+                    if (allAgentIds.isEmpty) {
+                        allAgentIds.append(appSettings.agentID)
+                    }
                     // If single threaded is not enabled for this conversation,
                     // then check in global app settings.
                     if !conversation.useLastConversation,


### PR DESCRIPTION
* Checked by creating a conversation with passing an agentIds and if only those agentIds are in the group 
* Tried creating a conversation with  withConversationAssignee and botIds and aganetIds and checked if the bot is replying or not   

