### PR TITLE
[CM-410] Add support for enabling CSAT from the Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [CM-410] Added support for enabling CSAT from the Dashboard.
+
 ## [5.6.1] - 2020-08-21
 
 ### Enhancements

--- a/Kommunicate/Classes/KMAppSettingsResponse.swift
+++ b/Kommunicate/Classes/KMAppSettingsResponse.swift
@@ -26,11 +26,11 @@ struct AppSetting: Decodable {
     let agentID: String
     let agentName, userName: String?
     let chatWidget: ChatWidgetResponse?
+    let collectFeedback: Bool?
 
     enum CodingKeys: String, CodingKey {
         case agentID = "agentId"
-        case agentName, userName
-        case chatWidget
+        case agentName, userName, chatWidget, collectFeedback
     }
 }
 

--- a/Kommunicate/Classes/KMAppUserDefaultHandler.swift
+++ b/Kommunicate/Classes/KMAppUserDefaultHandler.swift
@@ -10,20 +10,40 @@ import Foundation
 class KMAppUserDefaultHandler : NSObject {
     static let DEFAULT_SUITE_NAME =  "group.kommunicate.sdk"
 
-    static var sharedUserDefaults: UserDefaults? {
-        return UserDefaults(suiteName: DEFAULT_SUITE_NAME)
+    static let shared = KMAppUserDefaultHandler(
+        userDefaultSuite: UserDefaults(suiteName: DEFAULT_SUITE_NAME) ?? .standard
+    )
+
+    var isCSATEnabled: Bool {
+        set {
+            userDefaultSuite.set(newValue, forKey: Key.CSATEnabled)
+        }
+        get {
+            return userDefaultSuite.bool(forKey: Key.CSATEnabled)
+        }
     }
 
-    static func setBotType(_ botType: String, botId: String) {
-        KMAppUserDefaultHandler.sharedUserDefaults?.setValue(botType, forKey: botId)
+    private let userDefaultSuite: UserDefaults
+
+    init(userDefaultSuite: UserDefaults) {
+        self.userDefaultSuite = userDefaultSuite
+    }
+
+    func setBotType(_ botType: String, botId: String) {
+        userDefaultSuite.setValue(botType, forKey: botId)
     }
     
-    static func getBotType(botId: String) -> String? {
-        return KMAppUserDefaultHandler.sharedUserDefaults?.value(forKey: botId) as? String
+    func getBotType(botId: String) -> String? {
+        return userDefaultSuite.value(forKey: botId) as? String
     }
 
-    static func clear() {
-        let userDefaults = KMAppUserDefaultHandler.sharedUserDefaults
-        userDefaults?.removePersistentDomain(forName: KMAppUserDefaultHandler.DEFAULT_SUITE_NAME)
+    func clear() {
+        userDefaultSuite.removePersistentDomain(forName: KMAppUserDefaultHandler.DEFAULT_SUITE_NAME)
+    }
+}
+
+private extension KMAppUserDefaultHandler {
+    enum Key {
+        static let CSATEnabled = "CSAT_ENABLED"
     }
 }

--- a/Kommunicate/Classes/KMBotService.swift
+++ b/Kommunicate/Classes/KMBotService.swift
@@ -49,7 +49,7 @@ public struct KMBotService {
                     print("Bot detail fetched successfully for botId:\(botId) And Bot platform:",botDetail.aiPlatform as Any)
                     /// Add the botType and botId in user defaults
                     DispatchQueue.main.async {
-                        KMAppUserDefaultHandler.setBotType(botType, botId: botId)
+                        KMAppUserDefaultHandler.shared.setBotType(botType, botId: botId)
                         completion(.success(botDetail))
                     }
                 } catch let error as KMBotError {
@@ -103,7 +103,7 @@ public struct KMBotService {
     ///   - botId: Pass the botId for fetching bot type
     ///   - completion: Result with botType or `KMBotError`
     func fetchBotType(_ botId: String, completion: @escaping (Result<String, KMBotError>) -> ()) {
-        if let botType = KMAppUserDefaultHandler.getBotType(botId: botId) {
+        if let botType = KMAppUserDefaultHandler.shared.getBotType(botId: botId) {
             completion(.success(botType))
         } else {
             self.botDetail(botId: botId) { (result) in

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -44,6 +44,7 @@ open class KMConversationViewController: ALKConversationViewController {
     var topConstraintClosedView: NSLayoutConstraint?
     var conversationService = KMConversationService()
     var conversationDetail = ConversationDetail()
+    var userDefaults = KMAppUserDefaultHandler.shared
 
     private var converastionNavBarItemToken: NotificationToken? = nil
     private var channelMetadataUpdateToken: NotificationToken? = nil
@@ -388,10 +389,9 @@ extension KMConversationViewController {
         }
         conversationClosedView.clearFeedback()
         isClosedConversationViewHidden = false
-        guard let channelId = viewModel.channelKey,
-            !kmConversationViewConfiguration.isCSATOptionDisabled else {
-                return
-        }
+        let isCSATEnabled =
+            !kmConversationViewConfiguration.isCSATOptionDisabled && userDefaults.isCSATEnabled
+        guard let channelId = viewModel.channelKey, isCSATEnabled else { return }
         conversationDetail.feedbackFor(channelId: channelId.intValue) { [weak self] feedback in
             DispatchQueue.main.async {
                 guard let previousFeedback = feedback else {

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -157,6 +157,8 @@ open class Kommunicate: NSObject,Localizable{
                     case .success(let appSetting):
                         DispatchQueue.main.async {
                             kmAppSetting.updateAppsettings(chatWidgetResponse: appSetting.chatWidget)
+                            KMAppUserDefaultHandler.shared.isCSATEnabled
+                                = appSetting.collectFeedback ?? false
                             completion(response , error as NSError?)
                         }
                     case .failure( _) :
@@ -484,7 +486,7 @@ open class Kommunicate: NSObject,Localizable{
 
     private func clearUserDefaults() {
         let kmAppSetting = KMAppSettingService()
-        KMAppUserDefaultHandler.clear()
+        KMAppUserDefaultHandler.shared.clear()
         kmAppSetting.clearAppSettingsData()
     }
 }


### PR DESCRIPTION
### Summary

- Now, CSAT feature can be controlled from the Dashboard.
- Local setting is also present, which can be used to disable the CSAT feature.
- Rating screen will be shown only when it's enabled in the dashboard and not disabled locally.

### Testing

- Tested in these scenarios: when it's enabled/disabled in the Dashboard and disabled/enabled locally.
