### PR TITLE
Add a workflow to merge PR on green #trivial

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,29 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "ready"
+          MERGE_DELETE_BRANCH: true


### PR DESCRIPTION
- Added a GitHub action to merge a PR when it's ready.
- These checks will be performed before merging: `ready` label on PR, PR is approved and tests are successful.
- It will run on GitHub Actions.
- Merging this PR to master otherwise it won't run.