### PR TITLE
[CM-451] Add support for setting a prefilled message to send before launching a chat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+- [CM-451] Add support for setting a prefilled message to send before launching a chat.
+
 ## [5.7.0] - 2020-09-10
 
 ### Enhancements

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -502,6 +502,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Kommunicate_Tests/Pods-Kommunicate_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Applozic/Applozic.framework",
+				"${BUILT_PRODUCTS_DIR}/ApplozicSwift/ApplozicSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
+				"${BUILT_PRODUCTS_DIR}/MGSwipeTableCell/MGSwipeTableCell.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
@@ -510,6 +515,11 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Applozic.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ApplozicSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MGSwipeTableCell.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -12,6 +12,7 @@ target 'Kommunicate_Example' do
     pod 'Nimble'
     pod 'Quick'
     pod 'Nimble-Snapshots'
+    pod 'ApplozicSwift', :git => 'https://github.com/AppLozic/ApplozicSwift.git', :branch => 'CM-451'
   end
 end
 target 'Kommunicate_ExampleUITests' do

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -25,7 +25,7 @@ PODS:
   - Kommunicate (5.7.1):
     - ApplozicSwift (~> 5.10.2)
   - MGSwipeTableCell (1.6.11)
-  - Nimble (8.1.1)
+  - Nimble (8.1.2)
   - Nimble-Snapshots (8.2.1):
     - Nimble-Snapshots/Core (= 8.2.1)
   - Nimble-Snapshots/Core (8.2.1):
@@ -37,6 +37,7 @@ PODS:
   - SDWebImage/Core (5.7.4)
 
 DEPENDENCIES:
+  - ApplozicSwift (from `https://github.com/AppLozic/ApplozicSwift.git`, branch `CM-451`)
   - FBSnapshotTestCase (~> 2.1.4)
   - Kommunicate (from `../`)
   - Nimble
@@ -46,7 +47,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Applozic
-    - ApplozicSwift
     - FBSnapshotTestCase
     - iOSSnapshotTestCase
     - Kingfisher
@@ -57,8 +57,16 @@ SPEC REPOS:
     - SDWebImage
 
 EXTERNAL SOURCES:
+  ApplozicSwift:
+    :branch: CM-451
+    :git: https://github.com/AppLozic/ApplozicSwift.git
   Kommunicate:
     :path: "../"
+
+CHECKOUT OPTIONS:
+  ApplozicSwift:
+    :commit: baf6c21af00b7ffa8281c87c82c86d67f01d49bb
+    :git: https://github.com/AppLozic/ApplozicSwift.git
 
 SPEC CHECKSUMS:
   Applozic: e4c3d4a50d9feaa105608d9d8219686b6639b55b
@@ -68,11 +76,11 @@ SPEC CHECKSUMS:
   Kingfisher: 8050bc6f7f68cbf3908bd04df7ccbac188f6d6d6
   Kommunicate: a82fb7684c48eaae073f5f621a7fd6176bab5727
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
-  Nimble: 5f8a2fb6fa343a7242dfdd9d42f7267419d464b2
+  Nimble: 3864815b4703c7ebffba875973c70e854489fbae
   Nimble-Snapshots: 3a4750d83752625c8ebfdc588da105303ee2201e
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   SDWebImage: 48b88379b798fd1e4298f95bb25d2cdabbf4deb3
 
-PODFILE CHECKSUM: 0125fc433bf6d78b66627354de780554f7c16124
+PODFILE CHECKSUM: 1f8150cbf5a0aa06465dcae9c852c92901a33aec
 
 COCOAPODS: 1.9.3

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -175,10 +175,11 @@ open class KMConversationViewController: ALKConversationViewController {
             self.view.window != nil,
             let notificationData = notifData,
             !pushNotificationHelper.isNotificationForActiveThread(notificationData)
-            else { return }
+        else { return }
 
         unsubscribingChannel()
         viewModel.contactId = nil
+        viewModel.prefilledMessage = nil
         viewModel.channelKey = notificationData.groupId
         viewModel.conversationProxy = nil
         viewWillLoadFromTappingOnNotification()

--- a/Kommunicate/Classes/KMPushNotificationHelper.swift
+++ b/Kommunicate/Classes/KMPushNotificationHelper.swift
@@ -113,6 +113,11 @@ public class KMPushNotificationHelper {
     ///   - notification: notification that is tapped.
     public func refreshConversation(_ viewController: KMConversationViewController, with notification: NotificationData) {
         viewController.unsubscribingChannel()
+        if !self.isChatThreadIsOpen(notification,
+                                    userId: viewController.viewModel.contactId,
+                                    groupId: viewController.viewModel.channelKey) {
+            viewController.viewModel.prefilledMessage = nil
+        }
         viewController.viewModel.contactId = nil
         viewController.viewModel.channelKey = notification.groupId
         viewController.viewModel.conversationProxy = nil

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -279,22 +279,23 @@ open class Kommunicate: NSObject,Localizable{
 
      - Parameters:
      - clientGroupId: clientChannelKey of the Group.
-     - prefilledMessage: Prefilled message for chatbox.
      - viewController: ViewController from which the group chat will be launched.
+     - prefilledMessage: Prefilled message for chatbox.
      - completionHandler: Called with the information whether the conversation was
      shown or not.
 
      */
     @objc open class func showConversationWith(groupId clientGroupId: String,
+                                               from viewController: UIViewController,
                                                prefilledMessage: String? = nil,
-                                               from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
+                                               completionHandler: @escaping (Bool) -> Void) {
         let alChannelService = ALChannelService()
         alChannelService.getChannelInformation(nil, orClientChannelKey: clientGroupId) { (channel) in
             guard let channel = channel, let key = channel.key else {
                 completionHandler(false)
                 return
             }
-            self.openChatWith(groupId: key, prefilledMessage: prefilledMessage, from: viewController, completionHandler: { result in
+            self.openChatWith(groupId: key, from: viewController, prefilledMessage: prefilledMessage, completionHandler: { result in
                 completionHandler(result)
             })
         }
@@ -370,7 +371,10 @@ open class Kommunicate: NSObject,Localizable{
         vc.conversationViewController = conversationViewController
     }
 
-    class func openChatWith(groupId: NSNumber, prefilledMessage: String? = nil, from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
+    class func openChatWith(groupId: NSNumber,
+                            from viewController: UIViewController,
+                            prefilledMessage: String? = nil,
+                            completionHandler: @escaping (Bool) -> Void) {
         let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName, prefilledMessage: prefilledMessage)
         let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
         conversationViewController.viewModel = convViewModel

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -279,19 +279,22 @@ open class Kommunicate: NSObject,Localizable{
 
      - Parameters:
      - clientGroupId: clientChannelKey of the Group.
+     - prefilledMessage: Prefilled message for chatbox.
      - viewController: ViewController from which the group chat will be launched.
      - completionHandler: Called with the information whether the conversation was
      shown or not.
 
      */
-    @objc open class func showConversationWith(groupId clientGroupId: String, from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
+    @objc open class func showConversationWith(groupId clientGroupId: String,
+                                               prefilledMessage: String? = nil,
+                                               from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
         let alChannelService = ALChannelService()
         alChannelService.getChannelInformation(nil, orClientChannelKey: clientGroupId) { (channel) in
             guard let channel = channel, let key = channel.key else {
                 completionHandler(false)
                 return
             }
-            self.openChatWith(groupId: key, from: viewController, completionHandler: { result in
+            self.openChatWith(groupId: key, prefilledMessage: prefilledMessage, from: viewController, completionHandler: { result in
                 completionHandler(result)
             })
         }
@@ -367,8 +370,8 @@ open class Kommunicate: NSObject,Localizable{
         vc.conversationViewController = conversationViewController
     }
 
-    class func openChatWith(groupId: NSNumber, from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
-        let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName)
+    class func openChatWith(groupId: NSNumber, prefilledMessage: String? = nil, from viewController: UIViewController, completionHandler: @escaping (Bool) -> Void) {
+        let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName, prefilledMessage: prefilledMessage)
         let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
         conversationViewController.viewModel = convViewModel
         let navigationController = KMBaseNavigationViewController(rootViewController: conversationViewController)


### PR DESCRIPTION
* This PR depends on PR first review will be required in this:  https://github.com/AppLozic/ApplozicSwift/tree/CM-451 

* Added the passing option for the text in `Kommunicate. showConversationWith(groupId ` this can be used for passing the prefilled text while launching the chat.

CODE 
```swift
  Kommunicate.showConversationWith(groupId: "46383008", from: self, prefilledMessage: "Hi how are you doing") { (success) in
        }
```


Testing: 
Tested it passing the message and see if it's showing in the chatbox or not.
Tested it by switching the conversation by taping notification see if that is cleared or not.