### PR TITLE
[CM-474] Add send message API for sending text and rich messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 - [CM-451] Add support for setting a prefilled message to send before launching a chat.
 - [CM-356] Add support for language change rich message.
+- [CM-474] Add send message API for sending text and rich messages.
 
 ## [5.7.0] - 2020-09-10
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -32,9 +32,9 @@ PODS:
     - iOSSnapshotTestCase (~> 6.0)
     - Nimble (~> 8.0)
   - Quick (3.0.0)
-  - SDWebImage (5.9.2):
-    - SDWebImage/Core (= 5.9.2)
-  - SDWebImage/Core (5.9.2)
+  - SDWebImage (5.9.3):
+    - SDWebImage/Core (= 5.9.3)
+  - SDWebImage/Core (5.9.3)
 
 DEPENDENCIES:
   - ApplozicSwift (from `https://github.com/AppLozic/ApplozicSwift.git`, branch `CM-356`)
@@ -79,7 +79,7 @@ SPEC CHECKSUMS:
   Nimble: 3864815b4703c7ebffba875973c70e854489fbae
   Nimble-Snapshots: 3a4750d83752625c8ebfdc588da105303ee2201e
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
-  SDWebImage: 0b42b8719ab0c5257177d5894306e8a336b21cbb
+  SDWebImage: a31ee8e90a97303529e03fb0c333eae0eacb88e9
 
 PODFILE CHECKSUM: 5f724c8a1bd377e6039e389940a63be78912db87
 

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -356,6 +356,32 @@ open class Kommunicate: NSObject,Localizable{
         vc.present(navVC, animated: true, completion: nil)
     }
 
+    /// Sends a new message from the logged-in user.
+    /// - Parameter message: An instance of `KMMessage` object.
+    /// - Parameter completion: If there's any error while sending this message, then it will be returned in this block.
+    open class func sendMessage(
+        message: KMMessage,
+        completion: @escaping (Error?) -> ()) {
+
+        let alChannelService = ALChannelService()
+        alChannelService.getChannelInformation(nil, orClientChannelKey: message.conversationId) { channel in
+            guard let channel = channel, let key = channel.key else {
+                let noConversationError = NSError(domain:"No conversation found", code:0, userInfo:nil)
+                completion(noConversationError)
+                return
+            }
+            let alMessage = message.toALMessage()
+            alMessage.groupId = key
+            ALMessageService.sharedInstance().sendMessages(alMessage) { _, error in
+                guard error == nil else {
+                    completion(error)
+                    return
+                }
+                completion(nil)
+            }
+        }
+    }
+
     //MARK: - Internal methods
 
     class func configureListVC(_ vc: KMConversationListViewController) {

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -362,7 +362,11 @@ open class Kommunicate: NSObject,Localizable{
     open class func sendMessage(
         message: KMMessage,
         completion: @escaping (Error?) -> ()) {
-
+        guard !message.conversationId.isEmpty else {
+            let emptyConversationId = NSError(domain:"Empty conversation ID", code:0, userInfo:nil)
+            completion(emptyConversationId)
+            return
+        }
         let alChannelService = ALChannelService()
         alChannelService.getChannelInformation(nil, orClientChannelKey: message.conversationId) { channel in
             guard let channel = channel, let key = channel.key else {

--- a/Kommunicate/Classes/Models/KMMessageBuilder.swift
+++ b/Kommunicate/Classes/Models/KMMessageBuilder.swift
@@ -1,0 +1,65 @@
+//
+//  KMMessageBuilder.swift
+//  Kommunicate
+//
+//  Created by Mukesh on 22/10/20.
+//
+
+import Foundation
+import Applozic
+
+public class KMMessage: NSObject {
+    public var conversationId : String = ""
+    public var text: String = ""
+    public var metadata: [String : Any]?
+}
+
+public class KMMessageBuilder : NSObject {
+    private var message = KMMessage()
+
+    @discardableResult
+    @objc public func withConversationId(_ conversationId: String) ->  KMMessageBuilder {
+        message.conversationId = conversationId
+        return self
+    }
+
+    @discardableResult
+    @objc public func withText(_ text: String) ->  KMMessageBuilder {
+        message.text = text
+        return self
+    }
+
+    @discardableResult
+    @objc public func withMetadata(_ metadata: [String: Any]) ->  KMMessageBuilder {
+        message.metadata = metadata
+        return self
+    }
+
+    @objc public func build() ->  KMMessage {
+        return message
+    }
+}
+
+
+extension KMMessage {
+    func toALMessage() -> ALMessage {
+        let alMessage = ALMessage()
+        alMessage.to = nil
+        alMessage.contactIds = nil
+        alMessage.message = text
+        alMessage.type = AL_OUT_BOX
+        let date = Date().timeIntervalSince1970*1000
+        alMessage.createdAtTime = NSNumber(value: date)
+        alMessage.sendToDevice = false
+        alMessage.deviceKey = ALUserDefaultsHandler.getDeviceKeyString()
+        alMessage.shared = false
+        alMessage.fileMeta = nil
+        alMessage.storeOnDevice = false
+        alMessage.contentType = Int16(ALMESSAGE_CONTENT_DEFAULT)
+        alMessage.key = UUID().uuidString
+        alMessage.source = Int16(AL_SOURCE_IOS)
+        alMessage.conversationId = nil
+        alMessage.groupId = nil
+        return alMessage
+    }
+}


### PR DESCRIPTION
- Added a 'send message' function that supports sending text and rich messages.
- Also, added a message builder that is used for creating an `KMMessage` object.
- Tested by sending a message and launching a chat.