### PR TITLE
[CM-519] Enable document sharing and update Jira URL📱 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ## [Unreleased]
 
 ### Enhancements
-- [CM-451] Add support for setting a prefilled message to send before launching a chat.
-- [CM-356] Add support for language change rich message.
-- [CM-474] Add send message API for sending text and rich messages.
+- [CM-451] Added support for setting a prefilled message to send before launching a chat.
+- [CM-356] Added support for language change rich message.
+- [CM-474] Added send message API for sending text and rich messages.
+- [CM-519] Enabled document sharing in the default configuration.
 
 ## [5.7.0] - 2020-09-10
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -37,7 +37,7 @@ changelog_updated = git.modified_files.include? "CHANGELOG.md"
 fail "Any source code changes should have an entry in CHANGELOG.md." if !declared_trivial && !changelog_updated
 
 jira.check(
-  key: ["AL", "CM"],
-  url: "https://applozic.atlassian.net/browse",
+  key: ["CM"],
+  url: "https://kommunicate.atlassian.net/browse",
   fail_on_warning: false
 )

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -66,7 +66,7 @@ open class Kommunicate: NSObject,Localizable{
         config.navigationItemsForConversationList = navigationItemsForConversationList
         config.navigationItemsForConversationView = navigationItemsForConversationView
         config.disableSwipeInChatCell = true
-        config.chatBar.optionsToShow = .some([.camera, .location, .gallery, .video])
+        config.chatBar.optionsToShow = .some([.camera, .location, .gallery, .video, .document])
         return config
     }()
 


### PR DESCRIPTION
- Enabled document sharing in the default configuration.
- Also, updated the Jira URL in the `Dangerfile` to link to KM one.