### PR TITLE
Add typealias for KMChatBarConfiguration #trivial  

### DIFF
--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -27,6 +27,7 @@ public typealias KMConfiguration = ALKConfiguration
 public typealias KMMessageStyle = ALKMessageStyle
 public typealias KMStyle = ApplozicSwift.Style
 public typealias KMBaseNavigationViewController = ALKBaseNavigationViewController
+public typealias KMChatBarConfiguration = ALKChatBarConfiguration
 let faqIdentifier =  11223346
 
 enum KMLocalizationKey {


### PR DESCRIPTION
Added the typealias for KMChatBarConfiguration 

The config can be used in KM like below to set the style 
```
        // Text view's placeholder style
        KMChatBarConfiguration.TextView.placeholder = KMStyle(font: .font(.normal(size: 16)), text: .red)

        // Text view's text style
        KMChatBarConfiguration.TextView.text = KMStyle(font: .font(.normal(size: 18)), text: .red)
```

Testing:

Tested the config works or not.
