### PR TITLE
[CM-502] Add an option to launch a conversation with conversation list in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [CM-502] Added an option to launch a conversation with conversation list in the background.
+
 ### Fixes
 - Fixed an issue where back button was not changing in RTL.
 

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -417,20 +417,20 @@ open class Kommunicate: NSObject,Localizable{
         completionHandler: @escaping (Bool) -> Void
     ) {
         if showListOnBack {
-            let conversationVC = conversationListViewController()
-            conversationVC.channelKey = groupId
-            let navVC = KMBaseNavigationViewController(rootViewController: conversationVC)
+            let conversationListVC = conversationListViewController()
+            conversationListVC.channelKey = groupId
+            let navVC = KMBaseNavigationViewController(rootViewController: conversationListVC)
             navVC.modalPresentationStyle = .fullScreen
-            viewController.present(navVC, animated: false) {
+            viewController.present(navVC, animated: true) {
                 completionHandler(true)
             }
         } else {
             let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName, prefilledMessage: prefilledMessage)
-            let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
-            conversationViewController.viewModel = convViewModel
-            let navigationController = KMBaseNavigationViewController(rootViewController: conversationViewController)
-            navigationController.modalPresentationStyle = .fullScreen
-            viewController.present(navigationController, animated: false) {
+            let conversationVC = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
+            conversationVC.viewModel = convViewModel
+            let navVC = KMBaseNavigationViewController(rootViewController: conversationVC)
+            navVC.modalPresentationStyle = .fullScreen
+            viewController.present(navVC, animated: true) {
                 completionHandler(true)
             }
         }

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -281,23 +281,31 @@ open class Kommunicate: NSObject,Localizable{
      - clientGroupId: clientChannelKey of the Group.
      - viewController: ViewController from which the group chat will be launched.
      - prefilledMessage: Prefilled message for chatbox.
+     - showListOnBack: If true, then the conversation list will be shown on tap of the back button,
      - completionHandler: Called with the information whether the conversation was
      shown or not.
 
      */
-    @objc open class func showConversationWith(groupId clientGroupId: String,
-                                               from viewController: UIViewController,
-                                               prefilledMessage: String? = nil,
-                                               completionHandler: @escaping (Bool) -> Void) {
+    @objc open class func showConversationWith(
+        groupId clientGroupId: String,
+        from viewController: UIViewController,
+        prefilledMessage: String? = nil,
+        showListOnBack: Bool = false,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         let alChannelService = ALChannelService()
         alChannelService.getChannelInformation(nil, orClientChannelKey: clientGroupId) { (channel) in
             guard let channel = channel, let key = channel.key else {
                 completionHandler(false)
                 return
             }
-            self.openChatWith(groupId: key, from: viewController, prefilledMessage: prefilledMessage, completionHandler: { result in
+            self.openChatWith(
+                groupId: key,
+                from: viewController,
+                prefilledMessage: prefilledMessage,
+                showListOnBack: showListOnBack) { result in
                 completionHandler(result)
-            })
+            }
         }
     }
 
@@ -401,17 +409,31 @@ open class Kommunicate: NSObject,Localizable{
         vc.conversationViewController = conversationViewController
     }
 
-    class func openChatWith(groupId: NSNumber,
-                            from viewController: UIViewController,
-                            prefilledMessage: String? = nil,
-                            completionHandler: @escaping (Bool) -> Void) {
-        let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName, prefilledMessage: prefilledMessage)
-        let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
-        conversationViewController.viewModel = convViewModel
-        let navigationController = KMBaseNavigationViewController(rootViewController: conversationViewController)
-        navigationController.modalPresentationStyle = .fullScreen
-        viewController.present(navigationController, animated: true, completion: nil)
-        completionHandler(true)
+    class func openChatWith(
+        groupId: NSNumber,
+        from viewController: UIViewController,
+        prefilledMessage: String? = nil,
+        showListOnBack: Bool = false,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        if showListOnBack {
+            let conversationVC = conversationListViewController()
+            conversationVC.channelKey = groupId
+            let navVC = KMBaseNavigationViewController(rootViewController: conversationVC)
+            navVC.modalPresentationStyle = .fullScreen
+            viewController.present(navVC, animated: false) {
+                completionHandler(true)
+            }
+        } else {
+            let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: groupId, localizedStringFileName: defaultConfiguration.localizedStringFileName, prefilledMessage: prefilledMessage)
+            let conversationViewController = KMConversationViewController(configuration: Kommunicate.defaultConfiguration, conversationViewConfiguration: kmConversationViewConfiguration)
+            conversationViewController.viewModel = convViewModel
+            let navigationController = KMBaseNavigationViewController(rootViewController: conversationViewController)
+            navigationController.modalPresentationStyle = .fullScreen
+            viewController.present(navigationController, animated: false) {
+                completionHandler(true)
+            }
+        }
     }
 
     //MARK: - Private methods


### PR DESCRIPTION
- Added an option in the launch conversation API to show conversation list on tap of the back button.
- By default it is disabled, so on tap of the back button launch screen will be shown not the conversation list.
- Tested by creating conversations after enabling and disabling this option. Verified if the correct screen is shown in both the modes. Launch code:

```swift
Kommunicate.createConversation() { result in
    switch result {
    case .success(let conversationId):
        Kommunicate.showConversationWith(
            groupId: conversationId,
            from: self,
            showListOnBack: true,
            completionHandler: { success in
                print("conversation was shown")
            })

    case .failure(let kmConversationError):
        print("Failed to create a conversation: ", kmConversationError)
    }
}
```

