### PR TITLE
[CM-557] Update conversation feedback API to v2 to show the feedback on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 - [CM-502] Added an option to launch a conversation with conversation list in the background.
 - [CM-500] Added message character limit to limit the number of characters in a message.
+- [CM-557] Now, conversation feedback from the SDK will be shown in the Dashboard.
 
 ### Fixes
 - Fixed an issue where back button was not changing in RTL.

--- a/Kommunicate/Classes/Extensions/KMConversationService+ConversationFeedback.swift
+++ b/Kommunicate/Classes/Extensions/KMConversationService+ConversationFeedback.swift
@@ -13,6 +13,11 @@ extension KMConversationService {
         static let groupId = "groupId"
         static let comment = "comments"
         static let rating = "rating"
+        static let applicationId = "applicationId"
+        static let assigneeId = "supportAgentName"
+        static let userName = "name"
+        static let userId = "userId"
+        static let userInfo = "userInfo"
     }
 
     /// Fetches conversation feedback for the given group id.
@@ -58,15 +63,26 @@ extension KMConversationService {
     func submitFeedback(
         groupId: Int,
         feedback: Feedback,
+        userId: String,
+        userName: String,
+        assigneeId: String,
+        applicationId: String,
         completion: @escaping (Result<ConversationFeedback, FeedbackError>)->()
     ) {
         guard let url = URLBuilder.feedbackURLForSubmission().url else {
             completion(.failure(.api(.urlBuilding)))
             return
         }
+        let userInfo: [String: Any] = [
+            FeedbackParamKey.userName: userName,
+            FeedbackParamKey.userId: userId
+        ]
         var params: [String: Any] = [
             FeedbackParamKey.groupId: groupId,
-            FeedbackParamKey.rating: feedback.rating.rawValue
+            FeedbackParamKey.rating: feedback.rating.rawValue,
+            FeedbackParamKey.applicationId: applicationId,
+            FeedbackParamKey.assigneeId: assigneeId,
+            FeedbackParamKey.userInfo: userInfo
         ]
         if let comment = feedback.comment, !comment.isEmpty {
             params[FeedbackParamKey.comment] = [comment]

--- a/Kommunicate/Classes/Extensions/URLBuilder+ConversationFeedback.swift
+++ b/Kommunicate/Classes/Extensions/URLBuilder+ConversationFeedback.swift
@@ -14,7 +14,9 @@ extension URLBuilder {
     }
 
     static func feedbackURLForSubmission() -> URLBuilder {
-        let url = URLBuilder.kommunicateApi.add(path: "feedback")
+        let url = URLBuilder.kommunicateApi
+            .add(paths: ["feedback", "v2"])
+            .add(item: "sendAsMessage", value: true)
         return url
     }
 }

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -18,6 +18,7 @@ open class KMConversationViewController: ALKConversationViewController {
     private weak var ratingVC: RatingViewController?
     private let registerUserClientService = ALRegisterUserClientService()
     let kmBotService = KMBotService()
+    private var assigneeUserId: String?
 
     lazy var customNavigationView = ConversationVCNavBar(
         delegate: self,
@@ -259,6 +260,7 @@ open class KMConversationViewController: ALKConversationViewController {
                 return
             }
             self.customNavigationView.updateView(assignee: contact,channel: alChannel)
+            self.assigneeUserId = contact?.userId
         }
     }
 
@@ -286,6 +288,7 @@ open class KMConversationViewController: ALKConversationViewController {
             return
         }
         customNavigationView.updateView(assignee:contact ,channel: alChannel)
+        assigneeUserId = contact?.userId
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: customNavigationView)
     }
 
@@ -450,7 +453,11 @@ extension KMConversationViewController {
         guard let channelId = viewModel.channelKey else { return }
         conversationService.submitFeedback(
             groupId: channelId.intValue,
-            feedback: feedback
+            feedback: feedback,
+            userId: KMUserDefaultHandler.getUserId(),
+            userName: KMUserDefaultHandler.getDisplayName() ?? "",
+            assigneeId: assigneeUserId ?? "",
+            applicationId: KMUserDefaultHandler.getApplicationKey()
         ) { [weak self] result in
             switch result {
             case .success(let conversationFeedback):

--- a/Kommunicate/Classes/Models/ConversationFeedback.swift
+++ b/Kommunicate/Classes/Models/ConversationFeedback.swift
@@ -79,11 +79,7 @@ extension ConversationFeedbackSubmissionResponse: Decodable {
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         code = try values.decode(String.self, forKey: .code)
-        let feedbackResponse = try values.nestedContainer(
-            keyedBy: FeedbackResponseKeys.self,
-            forKey: .data
-        )
-        data = try feedbackResponse.decode(ConversationFeedback.self, forKey: .data)
+        data = try values.decode(ConversationFeedback.self, forKey: .data)
     }
 }
 


### PR DESCRIPTION
- Updated conversation feedback API to v2. Now, conversation feedback will be shown in the Dashboard as a feedback message is sent.
- Also, changed the request params and response parsing strategy.
- Tested by giving a feedback from the SDK, and it's shown like this in the dashboard:

![Screenshot 2020-12-03 at 1 35 57 PM](https://user-images.githubusercontent.com/5956714/100981262-9192f700-356c-11eb-87cf-6b7b5e544df2.png)
