### PR TITLE
[CM-579] Set default primary color and sent message's text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [CM-579] Set default primary color and sent message's text color.
+
 ## [5.10.0] - 2021-01-19
 
 ### Enhancements

--- a/Kommunicate/Classes/Extensions/Style+Color.swift
+++ b/Kommunicate/Classes/Extensions/Style+Color.swift
@@ -10,6 +10,7 @@ import Foundation
 extension Style {
     enum Color {
         enum Background: Int {
+            case primary = 0x5553B7
             case mediumGrey = 0xf0f0f0
             case lightGreyOne = 0xf9f9f9
             case darkYellow = 0xD6A64D

--- a/Kommunicate/Classes/KMAppSettingsService.swift
+++ b/Kommunicate/Classes/KMAppSettingsService.swift
@@ -43,9 +43,10 @@ class KMAppSettingService {
 
     func updateAppsettings(chatWidgetResponse: ChatWidgetResponse?) {
         guard let chatWidget = chatWidgetResponse,
-            var primaryColor = chatWidget.primaryColor
-            else {
-                return
+              var primaryColor = chatWidget.primaryColor
+        else {
+            setupDefaultSettings()
+            return
         }
         primaryColor = primaryColor.replacingOccurrences(of: "#", with: "")
         let appSettings = ALKAppSettings(primaryColor: primaryColor)
@@ -73,4 +74,11 @@ class KMAppSettingService {
         navigationBarProxy.barTintColor = nil
     }
 
+    private func setupDefaultSettings(primaryColor: String = UIColor.background(.primary).toHexString()) {
+        let appSettings = ALKAppSettings(primaryColor: primaryColor)
+        appSettings.sentMessageBackgroundColor = primaryColor
+        appSettings.attachmentIconsTintColor = primaryColor
+        appSettings.buttonPrimaryColor = primaryColor
+        appSettingsUserDefaults.updateOrSetAppSettings(appSettings: appSettings)
+    }
 }

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -122,6 +122,7 @@ open class Kommunicate: NSObject,Localizable{
         self.applicationId = applicationId
         ALUserDefaultsHandler.setApplicationKey(applicationId)
         Kommunicate.shared.defaultChatViewSettings()
+        Kommunicate.shared.setupDefaultStyle()
     }
 
     /**
@@ -498,6 +499,14 @@ open class Kommunicate: NSObject,Localizable{
         ALUserDefaultsHandler.setDebugLogsRequire(true)
         ALApplozicSettings.setSwiftFramework(true)
         ALApplozicSettings.hideMessages(withMetadataKeys: ["KM_ASSIGN", "KM_STATUS"])
+    }
+
+    func setupDefaultStyle() {
+        let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [ALKBaseNavigationViewController.self])
+        navigationBarProxy.tintColor = navigationBarProxy.tintColor ?? UIColor.white
+        navigationBarProxy.titleTextAttributes =
+            navigationBarProxy.titleTextAttributes ?? [NSAttributedString.Key.foregroundColor: UIColor.white]
+        KMMessageStyle.sentMessage = KMStyle(font: KMMessageStyle.sentMessage.font, text: .white)
     }
 
     /**


### PR DESCRIPTION
- When the primary color is not present in the App settings, then the default primary color('5553B7') will be set.
- Also, changed the default text color of sent message and navigation tint color to `white`.
- This change was required to match the default style with other platforms like web plugin.