### PR TITLE
[CM-581] Option to set the team ID when creating a new conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [CM-581] Added an option to set the team ID when creating a new conversation.
+
 ## [5.11.0] - 2021-02-01
 
 ### Enhancements

--- a/Kommunicate/Classes/KMConversation.swift
+++ b/Kommunicate/Classes/KMConversation.swift
@@ -21,6 +21,7 @@ import Applozic
     public var conversationTitle : String?
     public var conversationMetadata =  [AnyHashable : Any]()
     public var conversationAssignee : String?
+    public var teamId: String?
 
     public init(userId: String){
         self.userId = userId
@@ -102,6 +103,14 @@ import Applozic
     @discardableResult
     @objc public func withConversationAssignee(_ conversationAssignee: String) -> KMConversationBuilder {
         conversation.conversationAssignee = conversationAssignee
+        return self
+    }
+
+    /// To assign the conversation to a team, pass a team Id.
+    /// - Parameter teamId: Pass a team ID
+    @discardableResult
+    @objc public func withTeamId(_ teamId: String) -> KMConversationBuilder {
+        conversation.teamId = teamId
         return self
     }
 

--- a/Kommunicate/Classes/KMConversationService.swift
+++ b/Kommunicate/Classes/KMConversationService.swift
@@ -16,6 +16,7 @@ public struct ChannelMetadataKeys {
     static let kmOriginalTitle = "KM_ORIGINAL_TITLE"
     static let chatContext = "KM_CHAT_CONTEXT"
     static let languageTag = "kmUserLanguageCode"
+    static let teamId = "KM_TEAM_ID"
 }
 
 struct LocalizationKey {
@@ -296,6 +297,10 @@ public class KMConversationService: KMConservationServiceable,Localizable {
 
         if conversation.useOriginalTitle {
             metadata.setValue("true", forKey: ChannelMetadataKeys.kmOriginalTitle)
+        }
+
+        if let teamId = conversation.teamId, !teamId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            metadata.setValue(teamId, forKey: ChannelMetadataKeys.teamId)
         }
 
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,


### PR DESCRIPTION
- Added a team ID option in the `KMConversationBuilder` to assign a conversation to the team.
- This will be used when creating a new conversation.
- Tested by creating multiple new conversations with different team IDs.