### PR TITLE
[CM-635] Add an option to set the pre-chat view phone number regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [CM-635] Added an option to set the regex for validating phone number in the pre-chat view.
 ## [5.12.0] - 2021-02-16
 
 ### Enhancements

--- a/Kommunicate/Classes/KMPreChatFormViewController.swift
+++ b/Kommunicate/Classes/KMPreChatFormViewController.swift
@@ -16,6 +16,11 @@ open class KMPreChatFormViewController: UIViewController {
 
     public weak var delegate: KMPreChatFormViewControllerDelegate!
 
+    /// The regular expression pattern that will be used to match the phone number
+    /// user has submitted. By default, it's nil.
+    /// When it's nil, we use `NSDataDetector` to validate the phone number.
+    public var phoneNumberRegexPattern: String?
+
     var configuration: KMConfiguration!
     var formView: KMPreChatUserFormView!
     var sendInstructionsTapped:(()->())?
@@ -198,8 +203,13 @@ open class KMPreChatFormViewController: UIViewController {
             return Result.failure(TextFieldValidationError.invalidEmailAddress)
         }
 
+        let isValidNumber: ((String) -> Bool) = { number in
+            return self.phoneNumberRegexPattern != nil ?
+                number.matchesWithPattern(self.phoneNumberRegexPattern ?? ""):number.isValidPhoneNumber
+        }
+
         // Return invalidPhoneNumber error if phone number is present and not valid
-        if !phoneNumberText.isEmpty, !phoneNumberText.isValidPhoneNumber {
+        if !phoneNumberText.isEmpty, !isValidNumber(phoneNumberText) {
             return Result.failure(TextFieldValidationError.invalidPhoneNumber)
         }
         return Result.success

--- a/Kommunicate/Classes/String+Extension.swift
+++ b/Kommunicate/Classes/String+Extension.swift
@@ -40,6 +40,11 @@ extension String {
         let emailPredicate = NSPredicate(format:"SELF MATCHES %@", emailFormat)
         return emailPredicate.evaluate(with: self)
     }
+
+    func matchesWithPattern(_ pattern: String) -> Bool {
+        let numberPredicate = NSPredicate(format:"SELF MATCHES %@", pattern)
+        return numberPredicate.evaluate(with: self)
+    }
 }
 
 extension String {


### PR DESCRIPTION
- Added an option in the pre-chat view to set the regular expression from outside to validate the phone number.
- Earlier we were using `NSDataDetector` to confirm if the number passed by the user is a valid phone number.
- Now, we'll only check it against the regex passed from outside, and when the regex is not present we'll use `NSDataDetector` to validate.
- This was requested by customers who want to set custom rules based on their country.
- Tested by changing the digit count in the regex like this:
```swift
preChatVC.phoneNumberRegexPattern = "\\d{8}"
```