### PR TITLE
[CM-633] Add config options to show certain fields in the pre-chat view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 
 - [CM-635] Added an option to set the regex for validating phone number in the pre-chat view.
+- [CM-633] Added config options to show and make certain fields mandatory in the pre-chat view.
+
 ## [5.12.0] - 2021-02-16
 
 ### Enhancements

--- a/Example/Kommunicate/Base.lproj/Localizable.strings
+++ b/Example/Kommunicate/Base.lproj/Localizable.strings
@@ -26,6 +26,12 @@ PreChatViewEmailAndPhoneNumberEmptyError = "Please fill email or the phone numbe
 PreChatViewEmailInvalidError = "Please enter correct email address";
 /* Invalid Phone number error message */
 PreChatViewPhoneNumberInvalidError = "Please enter correct phone number";
+/* Empty Name error message */
+PreChatViewNameEmptyError = "Please enter your name";
+/* Empty Email error message */
+PreChatViewEmailEmptyError = "Please enter your email address";
+/* Empty Phone number error message */
+PreChatViewPhoneNumberEmptyError = "Please enter your phone number";
 /* Send instructions button title */
 PreChatViewSendInstructionsButtonTitle = "SUBMIT";
 /* Get Started description on top */

--- a/Kommunicate/Assets/KMPreChatUserFormView.xib
+++ b/Kommunicate/Assets/KMPreChatUserFormView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,12 +11,15 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="KMPreChatUserFormView" customModule="Kommunicate">
             <connections>
                 <outlet property="contentView" destination="iN0-l3-epB" id="rFl-fk-GLg"/>
+                <outlet property="emailStackView" destination="t3r-om-1is" id="1xB-cj-yMV"/>
                 <outlet property="emailTextField" destination="xcQ-oy-Jwa" id="Brf-Be-KOA"/>
                 <outlet property="emailTitleLabel" destination="ULe-o9-1SU" id="s74-lv-IMG"/>
                 <outlet property="errorMessageLabel" destination="WpO-nN-HX8" id="nwZ-Vv-pBl"/>
                 <outlet property="getStartedDescriptionLabel" destination="Ijs-Lv-CvG" id="gaB-MX-3SP"/>
+                <outlet property="nameStackView" destination="Icb-Fy-uj3" id="9LI-d0-66x"/>
                 <outlet property="nameTextField" destination="gfW-Jp-MRP" id="7Sf-OE-rsN"/>
                 <outlet property="nameTitleLabel" destination="mWE-0n-IEe" id="HWI-NL-cBX"/>
+                <outlet property="phoneNumberStackView" destination="Ubk-LH-Oxf" id="KIi-Zt-Ne2"/>
                 <outlet property="phoneNumberTextField" destination="V4C-hM-4bB" id="AZ6-oX-xHt"/>
                 <outlet property="phoneNumberTitle" destination="PiS-E8-Yb5" id="YOh-0Z-JDD"/>
                 <outlet property="sendInstructionsButton" destination="Mqs-QW-CcI" id="oSa-8E-BzT"/>
@@ -189,7 +192,7 @@
                                     <color key="textColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mqs-QW-CcI">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mqs-QW-CcI">
                                     <rect key="frame" x="0.0" y="40" width="345" height="36"/>
                                     <color key="backgroundColor" red="0.36078431372549019" green="0.3529411764705882" blue="0.65490196078431373" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
@@ -217,13 +220,13 @@
                     </constraints>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="5K0-aw-Fs0" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="15" id="Ts0-yl-L3J"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="5K0-aw-Fs0" secondAttribute="trailing" constant="15" id="TsP-Fe-Tpj"/>
                 <constraint firstItem="5K0-aw-Fs0" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="86" id="jfM-1x-0yx"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="110.5" y="252.5"/>
         </view>
     </objects>

--- a/Kommunicate/Assets/Localizable.strings
+++ b/Kommunicate/Assets/Localizable.strings
@@ -26,6 +26,12 @@ PreChatViewEmailAndPhoneNumberEmptyError = "Please fill email or the phone numbe
 PreChatViewEmailInvalidError = "Please enter correct email address";
 /* Invalid Phone number error message */
 PreChatViewPhoneNumberInvalidError = "Please enter correct phone number";
+/* Empty Name error message */
+PreChatViewNameEmptyError = "Please enter your name";
+/* Empty Email error message */
+PreChatViewEmailEmptyError = "Please enter your email address";
+/* Empty Phone number error message */
+PreChatViewPhoneNumberEmptyError = "Please enter your phone number";
 /* Send instructions button title */
 PreChatViewSendInstructionsButtonTitle = "SUBMIT";
 /* Get Started description on top */

--- a/Kommunicate/Classes/Views/KMPreChatUserFormView.swift
+++ b/Kommunicate/Classes/Views/KMPreChatUserFormView.swift
@@ -21,6 +21,11 @@ class CircleView: UIView {
 }
 
 class KMPreChatUserFormView: UIView, Localizable {
+    enum InputField {
+        case name
+        case email
+        case phoneNumber
+    }
 
     var localizationFileName: String!
 
@@ -39,6 +44,9 @@ class KMPreChatUserFormView: UIView, Localizable {
     @IBOutlet weak var topStackView: UIStackView!
 
     @IBOutlet weak var topConstraint: NSLayoutConstraint!
+    @IBOutlet weak var emailStackView: UIStackView!
+    @IBOutlet weak var nameStackView: UIStackView!
+    @IBOutlet weak var phoneNumberStackView: UIStackView!
 
     struct LocalizationKey {
         private static let prefix = "PreChatView"
@@ -82,6 +90,17 @@ class KMPreChatUserFormView: UIView, Localizable {
 
     func hideErrorLabel() {
         errorMessageLabel.text = ""
+    }
+
+    func hideField(_ field: InputField) {
+        switch field {
+        case .name:
+            nameStackView.isHidden = true
+        case.email:
+            emailStackView.isHidden = true
+        case .phoneNumber:
+            phoneNumberStackView.isHidden = true
+        }
     }
 
     private func placeholderWith(text: String) -> NSAttributedString {


### PR DESCRIPTION
- Added config options to show/hide certain fields in the pre-chat view.
- Also, added an option to set the mandatory fields, and if the user does not fill them, the error will be displayed.
- Moved `phoneNumberRegexPattern` to `PreChatConfiguration`.
- This was required to set the pre-chat view rules from outside.

Note: This PR is on top of #159 so make sure to merge that PR before this one.