### PR TITLE
[TD-1611] Show/hide away message on agent change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [TD-1611] Now, we'll show/hide away message on agent change.
+
 ## [5.13.0] - 2021-02-27
 
 ### Enhancements

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -502,6 +502,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Kommunicate_Tests/Pods-Kommunicate_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Applozic/Applozic.framework",
+				"${BUILT_PRODUCTS_DIR}/ApplozicSwift/ApplozicSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
+				"${BUILT_PRODUCTS_DIR}/MGSwipeTableCell/MGSwipeTableCell.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
@@ -510,6 +515,11 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Applozic.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ApplozicSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MGSwipeTableCell.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,6 +7,7 @@ target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
   target 'Kommunicate_Tests' do
     inherit! :search_paths
+    pod 'ApplozicSwift', :git => 'https://github.com/mukeshthawani/ApplozicSwift.git', :branch => 'tv-move'
     pod 'FBSnapshotTestCase' , '~> 2.1.4'
     pod 'Nimble'
     pod 'Quick'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -37,6 +37,7 @@ PODS:
   - SDWebImage/Core (5.9.5)
 
 DEPENDENCIES:
+  - ApplozicSwift (from `https://github.com/mukeshthawani/ApplozicSwift.git`, branch `tv-move`)
   - FBSnapshotTestCase (~> 2.1.4)
   - Kommunicate (from `../`)
   - Nimble
@@ -46,7 +47,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Applozic
-    - ApplozicSwift
     - FBSnapshotTestCase
     - iOSSnapshotTestCase
     - Kingfisher
@@ -57,8 +57,16 @@ SPEC REPOS:
     - SDWebImage
 
 EXTERNAL SOURCES:
+  ApplozicSwift:
+    :branch: tv-move
+    :git: https://github.com/mukeshthawani/ApplozicSwift.git
   Kommunicate:
     :path: "../"
+
+CHECKOUT OPTIONS:
+  ApplozicSwift:
+    :commit: 666819236ab7ffe740749f5f0d79be3ab4abb109
+    :git: https://github.com/mukeshthawani/ApplozicSwift.git
 
 SPEC CHECKSUMS:
   Applozic: 673eba55f167f1b06004ec8f959b356d3a59af66
@@ -73,6 +81,6 @@ SPEC CHECKSUMS:
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   SDWebImage: 0b2ba0d56479bf6a45ecddbfd5558bea93150d25
 
-PODFILE CHECKSUM: 04606b9a34e092208cf4fffc1fc90d102b10cf45
+PODFILE CHECKSUM: db01f2c73a423ef05b0c51863363a22c78a1afe7
 
 COCOAPODS: 1.10.1

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -270,7 +270,7 @@ open class KMConversationViewController: ALKConversationViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.conversationAssignedToDialogflowBot()
         }
-
+        messageStatusAndFetchBotType()
         // If the user was typing when the status changed
         view.endEditing(true)
         guard isClosedConversationViewHidden == isClosedConversation else { return }
@@ -352,10 +352,14 @@ open class KMConversationViewController: ALKConversationViewController {
         awayMessageView.constraint(withIdentifier: AwayMessageView.ConstraintIdentifier.awayMessageViewHeight.rawValue)?.constant = CGFloat(flag ? awayMessageheight : 0)
 
         /// Make sure to keep the height of bot character limit view if it's visible.
-        let botCharLimitViewHeight = self.charLimitView.isHidden ? 0 : MessageCharacterLimitManager.charLimitViewHeight
+        let charLimitViewHeight = charLimitView.constraint(withIdentifier: MessageCharacterLimitView.ConstraintIdentifier.messageCharacterLimitViewHeight.rawValue)?.constant ?? 0
+        let isChatLimitViewVisible = charLimitViewHeight > 0 && !charLimitView.isHidden
+        let botCharLimitViewHeight = isChatLimitViewVisible ? MessageCharacterLimitManager.charLimitViewHeight:0
 
         chatBar.headerViewHeight = flag ? awayMessageheight: botCharLimitViewHeight
         awayMessageView.showMessage(flag)
+        let indexPath = IndexPath(row: 0, section: viewModel.messageModels.count - 1)
+        moveTableViewToBottom(indexPath: indexPath)
     }
 
     private func hideAwayAndClosedView() {


### PR DESCRIPTION
- Now, away message's view will be updated on agent change. So, whenever a conversation is to an agent who is in away mode, then the away message will be shown.
- Earlier we were only checking the away status initially when the conversation is launched.
- Also, fixed an issue where the chat bar header view was visible after hiding away message due to `charLimitView` check in `showAwayMessage` method.
- Tested by changing conversation assignee to from bot to agent and vice versa. In case of bot there is no away message, so it will be hidden. Once a conversation is assigned to an agent, then the away message will be fetched from the server and shown to the user.
- Dependent on [this PR](https://github.com/AppLozic/ApplozicSwift/pull/384).