### PR TITLE
[TD-1606] Fix character limit issue for Dialogflow bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 
 - [TD-1611] Now, we'll show/hide away message on agent change.
+### Fixes
+
+- [TD-1606] Fixed an issue where character limit was not shown when a conversation is assigned to a Dialogflow bot.
 
 ## [5.13.0] - 2021-02-27
 

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -55,7 +55,17 @@ open class KMConversationViewController: ALKConversationViewController {
     var conversationService = KMConversationService()
     var conversationDetail = ConversationDetail()
     var userDefaults = KMAppUserDefaultHandler.shared
-    var isConversationAssignedToDialogflowBot = false
+    var isConversationAssignedToDialogflowBot = false {
+        didSet {
+            if isConversationAssignedToDialogflowBot {
+                botCharLimitManager.isCharLimitCheckEnabled = true
+                messageCharLimitManager.isCharLimitCheckEnabled = false
+            } else {
+                messageCharLimitManager.isCharLimitCheckEnabled = true
+                botCharLimitManager.isCharLimitCheckEnabled = false
+            }
+        }
+    }
     let awayMessageheight = 80.0
 
     private var converastionNavBarItemToken: NotificationToken? = nil

--- a/Kommunicate/Classes/MessageCharacterLimitManager.swift
+++ b/Kommunicate/Classes/MessageCharacterLimitManager.swift
@@ -20,6 +20,7 @@ class MessageCharacterLimitManager: NSObject {
     static let charLimitViewHeight = 80.0
     weak var delegate: MessageCharacterLimitDelegate?
     var messageToShow: String = ""
+    var isCharLimitCheckEnabled = true
 
     private let chatBar: ALKChatBar
     private let charLimitView: MessageCharacterLimitView
@@ -43,6 +44,7 @@ class MessageCharacterLimitManager: NSObject {
     /// This method will check the character limit.
     /// - Parameter text: Entered text in the text view
     func checkCharLimit(_ text: String) {
+        guard isCharLimitCheckEnabled else { return }
         let extraCharacters = text.count - limit
         let limitExceeded = extraCharacters > 0
         guard !text.isEmpty && limitExceeded else {


### PR DESCRIPTION
- Fixed an issue where character limit was not shown when a conversation is assigned to a Dialogflow bot.
- Added an option to enable/disable the character limit check to activate/deactivate the check when bot is present.
- Tested by assigning a conversation to a Dialogflow bot and a normal agent.