### PR TITLE
[TD-1667] Add an option to hide the message input when assigned to bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 
 ## [Unreleased]
 
+### Enhancements
+
+- [TD-1667] Added a configuration option that prevents the user from sending a message when a conversation is assigned to a bot.
 ## [5.14.0] - 2021-03-24Z
 
 ### Enhancements

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -502,6 +502,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Kommunicate_Tests/Pods-Kommunicate_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Applozic/Applozic.framework",
+				"${BUILT_PRODUCTS_DIR}/ApplozicSwift/ApplozicSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
+				"${BUILT_PRODUCTS_DIR}/MGSwipeTableCell/MGSwipeTableCell.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
@@ -510,6 +515,11 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Applozic.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ApplozicSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MGSwipeTableCell.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,6 +7,7 @@ target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
   target 'Kommunicate_Tests' do
     inherit! :search_paths
+    pod 'ApplozicSwift', :git => 'https://github.com/mukeshthawani/ApplozicSwift.git', :branch => 'chatbar-hide'
     pod 'FBSnapshotTestCase' , '~> 2.1.4'
     pod 'Nimble'
     pod 'Quick'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -37,6 +37,7 @@ PODS:
   - SDWebImage/Core (5.9.5)
 
 DEPENDENCIES:
+  - ApplozicSwift (from `https://github.com/mukeshthawani/ApplozicSwift.git`, branch `chatbar-hide`)
   - FBSnapshotTestCase (~> 2.1.4)
   - Kommunicate (from `../`)
   - Nimble
@@ -46,7 +47,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Applozic
-    - ApplozicSwift
     - FBSnapshotTestCase
     - iOSSnapshotTestCase
     - Kingfisher
@@ -57,8 +57,16 @@ SPEC REPOS:
     - SDWebImage
 
 EXTERNAL SOURCES:
+  ApplozicSwift:
+    :branch: chatbar-hide
+    :git: https://github.com/mukeshthawani/ApplozicSwift.git
   Kommunicate:
     :path: "../"
+
+CHECKOUT OPTIONS:
+  ApplozicSwift:
+    :commit: 045c7fe10297e658d90f0b8d7d0dc74c3c916d5f
+    :git: https://github.com/mukeshthawani/ApplozicSwift.git
 
 SPEC CHECKSUMS:
   Applozic: 673eba55f167f1b06004ec8f959b356d3a59af66
@@ -73,6 +81,6 @@ SPEC CHECKSUMS:
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   SDWebImage: 0b2ba0d56479bf6a45ecddbfd5558bea93150d25
 
-PODFILE CHECKSUM: 04606b9a34e092208cf4fffc1fc90d102b10cf45
+PODFILE CHECKSUM: 01647b4d2c8bb748b4ab07816f294214dd3f68f7
 
 COCOAPODS: 1.10.1

--- a/Kommunicate/Classes/ConversationDetail.swift
+++ b/Kommunicate/Classes/ConversationDetail.swift
@@ -13,6 +13,7 @@ class ConversationDetail {
     let channelService = ALChannelService()
     let userService = ALUserService()
     let contactDbService = ALContactDBService()
+    let channelDbService = ALChannelDBService()
 
     func conversationAssignee(groupId: NSNumber?, userId: String?) -> (ALContact?,ALChannel?) {
         // Check if group conversation.
@@ -86,6 +87,23 @@ class ConversationDetail {
         })
     }
 
+    func isAssignedToBot(groupID: Int) -> Bool {
+        guard let assigneeId = assigneeUserIdFor(groupID: groupID),
+              let channelUserX = channelDbService.loadChannelUserX(byUserId: groupID as NSNumber, andUserId: assigneeId),
+              let userRole = channelUserX.role as? Int else {
+            return false
+        }
+        return userRole == KMGroupUser.RoleType.bot.rawValue
+    }
+
+    private func assigneeUserIdFor(groupID: Int) -> String? {
+        guard let channel = channelService.getChannelByKey(groupID as NSNumber),
+              channel.type == Int16(SUPPORT_GROUP.rawValue),
+              let assigneeId = channel.metadata?[KMBotService.conversationAssignee] as? String else {
+            return nil
+        }
+        return assigneeId
+    }
 }
 
 extension ALChannel {

--- a/Kommunicate/Classes/KMConversationViewConfiguration.swift
+++ b/Kommunicate/Classes/KMConversationViewConfiguration.swift
@@ -16,6 +16,8 @@ public struct KMConversationViewConfiguration {
     public var isCSATOptionDisabled: Bool = false
      /// Start new conversation icon in conversation list.
     public var startNewButtonIcon : UIImage? = UIImage(named: "icon_new_chat_red", in: Bundle.kommunicate, compatibleWith: nil)
+    /// If enabled, the user can't send a message when a conversation is assigned to a bot.
+    public var restrictMessageTypingWithBots = false
 
     public init() { }
 }

--- a/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Kommunicate/Classes/KMConversationViewController.swift
@@ -138,6 +138,7 @@ open class KMConversationViewController: ALKConversationViewController {
         super.viewWillDisappear(animated)
         hideAwayAndClosedView()
         isConversationAssignedToDialogflowBot = false
+        isChatBarHidden = false
     }
 
     override open func newMessagesAdded() {
@@ -271,6 +272,7 @@ open class KMConversationViewController: ALKConversationViewController {
             }
             self.customNavigationView.updateView(assignee: contact,channel: alChannel)
             self.assigneeUserId = contact?.userId
+            self.hideInputBarIfAssignedToBot()
         }
     }
 
@@ -375,6 +377,15 @@ open class KMConversationViewController: ALKConversationViewController {
     private func hideAwayAndClosedView() {
         isAwayMessageViewHidden = true
         isClosedConversationViewHidden = true
+    }
+
+    private func hideInputBarIfAssignedToBot() {
+        guard kmConversationViewConfiguration.restrictMessageTypingWithBots,
+              let groupId = viewModel.channelKey else {
+            return
+        }
+        let isAssignedToBot = conversationDetail.isAssignedToBot(groupID: Int(truncating: groupId))
+        isChatBarHidden = isAssignedToBot
     }
 
     open override func sendQuickReply(_ text: String,


### PR DESCRIPTION
## Summary
- Added a configuration option that prevents the user from sending a message when a conversation is assigned to a bot.
- It's disabled by default.

## Motivation
There are some cases where a user should just tap on rich message buttons when a conversation is assigned to a bot.

## Testing
Tested by changing the value from AppDelegate:
`Kommunicate.kmConversationViewConfiguration.restrictMessageTypingWithBots = true`

Dependent on [this PR](https://github.com/AppLozic/ApplozicSwift/pull/388).