### PR TITLE
[TD-1673] Update conversation assignee using createConversation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 ### Enhancements
 
 - [TD-1667] Added a configuration option that prevents the user from sending a message when a conversation is assigned to a bot.
+- [TD-1673] Now, the conversation assignee can be updated in an existing conversation using `Kommunicate.createConversation()` method.
+
 ## [5.14.0] - 2021-03-24Z
 
 ### Enhancements

--- a/Dangerfile
+++ b/Dangerfile
@@ -37,7 +37,7 @@ changelog_updated = git.modified_files.include? "CHANGELOG.md"
 fail "Any source code changes should have an entry in CHANGELOG.md." if !declared_trivial && !changelog_updated
 
 jira.check(
-  key: ["CM"],
+  key: ["TD"],
   url: "https://kommunicate.atlassian.net/browse",
   fail_on_warning: false
 )

--- a/Kommunicate/Classes/Extensions/URLBuilder+Assignment.swift
+++ b/Kommunicate/Classes/Extensions/URLBuilder+Assignment.swift
@@ -1,0 +1,20 @@
+//
+//  URLBuilder+Assignment.swift
+//  Kommunicate
+//
+//  Created by Mukesh on 08/04/21.
+//
+
+import Foundation
+
+extension URLBuilder {
+    static func assigneeChangeURL(groupId: Int, assigneeUserId assignee: String) -> URLBuilder {
+        let url = URLBuilder.chatApi
+            .add(paths: ["rest", "ws", "group", "assignee", "change"])
+            .add(item: "groupId", value: groupId)
+            .add(item: "assignee", value: assignee)
+            .add(item: "switchAssignee", value: true)
+            .add(item: "takeOverFromBot", value: true)
+        return url
+    }
+}

--- a/Kommunicate/Classes/KMConversationService.swift
+++ b/Kommunicate/Classes/KMConversationService.swift
@@ -42,6 +42,12 @@ public class KMConversationService: KMConservationServiceable,Localizable {
         public var error: Error? = nil
     }
 
+    enum ServiceError: Error {
+        case urlCreation
+        case jsonConversion
+        case api(error: Error?)
+    }
+
     let groupMetadata: NSMutableDictionary = {
         let metadata = NSMutableDictionary(
             dictionary: ALChannelService().metadataToHideActionMessagesAndTurnOffNotifications())
@@ -54,6 +60,7 @@ public class KMConversationService: KMConservationServiceable,Localizable {
         metadata.addEntries(from: messageMetadata)
         return metadata
     }()
+    let channelService = ALChannelService()
 
     //MARK: - Initialization
 
@@ -71,11 +78,25 @@ public class KMConversationService: KMConservationServiceable,Localizable {
         completion: @escaping (Response)->()) {
 
         if let clientId = conversation.clientConversationId, !clientId.isEmpty {
-            self.isGroupPresent(clientId: clientId, completion: {
-                present in
+            self.isGroupPresent(clientId: clientId, completion: { present, channel in
                 if present {
+                    let groupID = Int(truncating: channel?.key ?? 0)
                     let response = Response(success: true, clientChannelKey: clientId, error: nil)
-                    completion(response)
+                    guard let currentAssignee = self.assigneeUserIdFor(groupId: groupID),
+                          conversation.conversationAssignee != nil,
+                          conversation.conversationAssignee != currentAssignee else {
+                        completion(response)
+                        return
+                    }
+                    self.assignConversation(groupId: groupID, to: conversation.conversationAssignee ?? "") { result in
+                        switch result {
+                        case .success:
+                            completion(response)
+                        case .failure(let error):
+                            let errorResponse = Response(success: false, clientChannelKey: clientId, error: error)
+                            completion(errorResponse)
+                        }
+                    }
                 } else {
                     self.createNewChannelAndConversation(conversation: conversation, completion: { response in
                         completion(response)
@@ -181,7 +202,7 @@ public class KMConversationService: KMConservationServiceable,Localizable {
                 }
                 clientId = newClientId
                 self.isGroupPresent(clientId: newClientId, completion: {
-                    present in
+                    present, channel in
                     if present {
                         let response = Response(success: true, clientChannelKey: newClientId, error: nil)
                         completion(response)
@@ -333,15 +354,15 @@ public class KMConversationService: KMConservationServiceable,Localizable {
         return agentIds.map { createAgentGroupUserFrom(agentId: $0) }
     }
 
-    private func isGroupPresent(clientId: String, completion:@escaping (_ isPresent: Bool)->()){
+    private func isGroupPresent(clientId: String, completion:@escaping (_ isPresent: Bool, _ channel: ALChannel?)->()){
         let client = ALChannelService()
         client.getChannelInformation(byResponse: nil, orClientChannelKey: clientId, withCompletion: {
             error, channel, response in
-            guard channel != nil else {
-                completion(false)
+            guard let channel = channel else {
+                completion(false, nil)
                 return
             }
-            completion(true)
+            completion(true, channel)
         })
     }
 
@@ -413,5 +434,54 @@ public class KMConversationService: KMConservationServiceable,Localizable {
         }
         return allBotIds
     }
+
+    private func assignConversation(
+        groupId: Int,
+        to user: String,
+        completion: @escaping(Result<[String: Any], ServiceError>) -> ()
+    ) {
+        guard let url = URLBuilder
+                .assigneeChangeURL(groupId: groupId, assigneeUserId: user).url else {
+            completion(.failure(.urlCreation))
+            return
+        }
+
+        let theRequest: NSMutableURLRequest? =
+            ALRequestHandler.createPatchRequest(
+                withUrlString: url.absoluteString,
+                paramString: nil
+            )
+        ALResponseHandler.authenticateAndProcessRequest(theRequest, andTag: "KM-ASSIGNEE-CHANGE") {
+            (json, error) in
+            guard error == nil else {
+                completion(.failure(.api(error: error)))
+                return
+            }
+            guard let dict = json as? [String: Any] else {
+                completion(.failure(.jsonConversion))
+                return
+            }
+            completion(.success(dict))
+        }
+    }
+
+    private func assigneeUserIdFor(groupId: Int) -> String? {
+        guard let channel = channelService.getChannelByKey(groupId as NSNumber),
+              let assigneeUserId = channel.assigneeUserId else {
+            return nil
+        }
+        return assigneeUserId
+    }
 }
 
+extension ALChannel {
+    static let ConversationAssignee = "CONVERSATION_ASSIGNEE"
+
+    var assigneeUserId: String? {
+        guard type == Int16(SUPPORT_GROUP.rawValue),
+              let assigneeId = metadata?[ALChannel.ConversationAssignee] as? String else {
+            return nil
+        }
+        return assigneeId
+    }
+}

--- a/Kommunicate/Classes/KMConversationService.swift
+++ b/Kommunicate/Classes/KMConversationService.swift
@@ -83,12 +83,13 @@ public class KMConversationService: KMConservationServiceable,Localizable {
                     let groupID = Int(truncating: channel?.key ?? 0)
                     let response = Response(success: true, clientChannelKey: clientId, error: nil)
                     guard let currentAssignee = self.assigneeUserIdFor(groupId: groupID),
-                          conversation.conversationAssignee != nil,
-                          conversation.conversationAssignee != currentAssignee else {
+                          let newAssignee = conversation.conversationAssignee,
+                          !newAssignee.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                          newAssignee != currentAssignee else {
                         completion(response)
                         return
                     }
-                    self.assignConversation(groupId: groupID, to: conversation.conversationAssignee ?? "") { result in
+                    self.assignConversation(groupId: groupID, to: newAssignee) { result in
                         switch result {
                         case .success:
                             completion(response)

--- a/Kommunicate/Classes/Kommunicate.swift
+++ b/Kommunicate/Classes/Kommunicate.swift
@@ -227,8 +227,8 @@ open class Kommunicate: NSObject,Localizable{
                     // If single threaded is not enabled for this conversation,
                     // then check in global app settings.
                     if !conversation.useLastConversation,
-                        let chatWidget = appSettings.chatWidget,
-                        let isSingleThreaded = chatWidget.isSingleThreaded {
+                       let chatWidget = appSettings.chatWidget,
+                       let isSingleThreaded = chatWidget.isSingleThreaded {
                         conversation.useLastConversation = isSingleThreaded
                     }
                 case .failure(let error):
@@ -247,11 +247,13 @@ open class Kommunicate: NSObject,Localizable{
                         botIds: conversation.botIds ?? [])
                 }
                 service.createConversation(conversation: conversation, completion: { response in
-                    guard let conversationId = response.clientChannelKey else {
-                        completion(.failure(KMConversationError.api(response.error)))
-                        return;
+                    DispatchQueue.main.async {
+                        guard let conversationId = response.clientChannelKey else {
+                            completion(.failure(KMConversationError.api(response.error)))
+                            return;
+                        }
+                        completion(.success(conversationId))
                     }
-                    completion(.success(conversationId))
                 })
             }
         } else {

--- a/Kommunicate/Classes/URLBuilder.swift
+++ b/Kommunicate/Classes/URLBuilder.swift
@@ -21,6 +21,14 @@ final class URLBuilder {
         return URLBuilder(host: "api.kommunicate.io")
     }
 
+    static var chatApi: URLBuilder {
+        guard let baseURL = URL(string: ALUserDefaultsHandler.getBASEURL()),
+              let host = baseURL.host else {
+            return URLBuilder(host: "")
+        }
+        return URLBuilder(host: host)
+    }
+
     static var helpcenterApi: URLBuilder {
         guard let baseUrl = ALUserDefaultsHandler.getBASEURL() else {
             return URLBuilder(host: "helpcenter.kommunicate.io")


### PR DESCRIPTION
## Summary
- Now, the conversation assignee can be updated in an existing conversation using `Kommunicate.createConversation()` method.
- This will work for existing conversations. For new conversation, create conversation method will create a new conversation.

## Testing
Tested by updating the assignee in an existing conversation.
```swift
let kmConversation = KMConversationBuilder()
    .withConversationAssignee("new-assignee")
    .withClientConversationId("myfirstconversation")
    .useLastConversation(false)
    .build()

Kommunicate.createConversation(conversation: kmConversation) { result in
    switch result {
    case .success(let conversationId):
        print("Conversation id: ",conversationId)
        Kommunicate.showConversationWith(groupId: conversationId, from: self) {
            shown in
            print("Conversation shown")
        }
    case .failure(let kmConversationError):
        print("Failed to create a conversation: ", kmConversationError)
    }
}
```