### PR TITLE
Away message status Flutter iOS crash #trivial

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -227,7 +227,7 @@ open class KMConversationViewController: ALKConversationViewController {
                 DispatchQueue.main.async {
                     switch result {
                     case .success(let message):
-                        guard !message.isEmpty else { return }
+                        guard type(of: message) == String.self, !message.isEmpty else { return }
                         self.isAwayMessageViewHidden = false
                         self.awayMessageView.set(message: message)
                         /// Fetch the bot type


### PR DESCRIPTION
## Summary
Added a check for the type of the awayMessage variable