### PR TITLE
[CM-759] Dynamic ReplyMeta Data is not reaching Webhook | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
-
+- [CM-759] Fix for reply meta not reaching webhook when default chatContextData is exists.
 - [CM-743] Updated reference images for snapshot tests
 
 ## [6.3.1] - 2021-11-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
-- [CM-759] Fix for reply meta not reaching webhook when default chatContextData is exists.
+- [CM-759] Fix for reply meta not reaching webhook when default chatContextData exists.
 - [CM-743] Updated reference images for snapshot tests
 
 ## [6.3.1] - 2021-11-30

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
   - Kingfisher (7.0.0)
-  - Kommunicate (6.3.0):
+  - Kommunicate (6.3.1):
     - ApplozicSwift (~> 6.4.0)
   - Nimble (9.2.1)
   - Nimble-Snapshots (9.3.0):
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kingfisher: 5efc54fec3980f92354898532e562cc17f31efb4
-  Kommunicate: b7e902088e632255c7d8062c754a2ac89dc692de
+  Kommunicate: d92210786b7fbf5575ca9e333d73dd4ba0d4b2b6
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Nimble-Snapshots: 97270cd48f0e6eebd6c80ccf7dd35d4e57fb9997
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -399,26 +399,23 @@ open class KMConversationViewController: ALKConversationViewController {
                     try configuration.updateUserLanguage(tag: updatedLanguage)
                 }
 
-                guard let messageMetadata = configuration.messageMetadata as? [String: Any],let jsonData = messageMetadata["KM_CHAT_CONTEXT"] as? String,!jsonData.isEmpty ,let data =  jsonData.data(using: .utf8) else {
+                guard let messageMetadata = configuration.messageMetadata as? [String: Any],
+                      let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,!jsonData.isEmpty,
+                      let data =  jsonData.data(using: .utf8),
+                      let chatContextData = try JSONSerialization.jsonObject(with: data,options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any]
+                else {
                         viewModel.send(message: text, metadata: customMetadata)
                         return
                     }
-           
+        
                 if customMetadata.isEmpty {
                     viewModel.send(message: text, metadata: messageMetadata)
                     return
                 }
-            
-                guard  let chatContextData = try JSONSerialization.jsonObject(with: data,options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any] else {
-                    viewModel.send(message: text, metadata: customMetadata)
-                    return
-                }
-            
-                var replyMetaData = customMetadata["KM_CHAT_CONTEXT"] as? [String: Any]
+                var replyMetaData = customMetadata[ChannelMetadataKeys.chatContext] as? [String: Any]
                 replyMetaData?.merge(chatContextData) { $1 }
-                let  metaDataToSend = ["KM_CHAT_CONTEXT":replyMetaData]
+                let  metaDataToSend = [ChannelMetadataKeys.chatContext:replyMetaData]
                 viewModel.send(message: text, metadata: metaDataToSend)
-
         } catch {
             print("Error while sending quick reply message %@", error.localizedDescription)
         }


### PR DESCRIPTION
## Summary
Reply Meta Data is not sending to the backend.

## Root Cause
Reply Meta Data & DefaultChatContext MetaData dictionaries has values under same key “KM_CHAT_CONTEXT“ . When we try to merge both dictionaries, one is replaced by another.At the end we are losing one of the dictionary values.

## Testing
I have tested locally.