### PR TITLE
[CM-780] Add support to update Team ID - KM SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
+- [CM-780] Added Support for Updating team Id for a conversation
 - [CM-759] Fix for reply meta not reaching webhook when default chatContextData exists.
 - [CM-709] Added Event Listeners 
 - [CM-743] Updated reference images for snapshot tests

--- a/Example/Kommunicate/ViewController.swift
+++ b/Example/Kommunicate/ViewController.swift
@@ -12,7 +12,7 @@ import Kommunicate
 
 class ViewController: UIViewController {
     let activityIndicator = UIActivityIndicatorView(style: .gray)
-let teamid = "67476167"
+
     override func viewDidLoad() {
         super.viewDidLoad()
         activityIndicator.center = CGPoint(x: view.bounds.size.width/2,
@@ -20,62 +20,21 @@ let teamid = "67476167"
         view.addSubview(activityIndicator)
         view.bringSubviewToFront(activityIndicator)
     }
-// I have changed the launchConversation method for testing purpose, Will remove all the changes after
+
     @IBAction func launchConversation(_ sender: Any) {
         activityIndicator.startAnimating()
         view.isUserInteractionEnabled = false
         
-        let kommunicateConversationBuilder = KMConversationBuilder()
-            .useLastConversation(true)
-        let conversation = kommunicateConversationBuilder.build()
-        let teamid = "67476167"
-
-        Kommunicate.createConversation(conversation: conversation) { (result) in
-            switch result {
-            case .success(let conversationId):
-                self.activityIndicator.stopAnimating()
-                self.view.isUserInteractionEnabled = true
-                DispatchQueue.main.async {
-                    Kommunicate.showConversationWith(groupId: conversationId, from: self, completionHandler: { success in
-                        guard success else {
-                            print("Failed to create show conversation")
-//                            completion(KommunicateError.conversationNotPresent)
-                            return
-                        }
-                        let teamid = "67476167"
-
-//
-                        Kommunicate.updateTeamId(conversation: conversation, teamId: teamid){ (result) in
-                            switch result {
-                            case .success(let groupId):
-                                print("Successfully to udpated the team id \(groupId)")
-
-                            case.failure(_):
-                                print("Failed to udpate the team id")
-                            }
-
-                        }
-//
-                        print("Kommunicate: conversation was shown")
-//                        completion(nil)
-                    })
-                }
-            case .failure(_):
-//                completion(KommunicateError.conversationCreateFailed)
-                return
+        Kommunicate.createAndShowConversation(from: self, completion: {
+            error in
+            self.activityIndicator.stopAnimating()
+            self.view.isUserInteractionEnabled = true
+            if error != nil {
+                print("Error while launching")
             }
-        }
-      
-//
-//        Kommunicate.createAndShowConversation(from: self, completion: {
-//            error in
-//            self.activityIndicator.stopAnimating()
-//            self.view.isUserInteractionEnabled = true
-//            if error != nil {
-//                print("Error while launching")
-//            }
-//        })
+        })
     }
+    
     @IBAction func logoutAction(_ sender: Any) {
         Kommunicate.logoutUser { (result) in
             switch result {

--- a/Example/Kommunicate/ViewController.swift
+++ b/Example/Kommunicate/ViewController.swift
@@ -12,7 +12,7 @@ import Kommunicate
 
 class ViewController: UIViewController {
     let activityIndicator = UIActivityIndicatorView(style: .gray)
-
+let teamid = "67476167"
     override func viewDidLoad() {
         super.viewDidLoad()
         activityIndicator.center = CGPoint(x: view.bounds.size.width/2,
@@ -20,19 +20,61 @@ class ViewController: UIViewController {
         view.addSubview(activityIndicator)
         view.bringSubviewToFront(activityIndicator)
     }
-
+// I have changed the launchConversation method for testing purpose, Will remove all the changes after
     @IBAction func launchConversation(_ sender: Any) {
         activityIndicator.startAnimating()
         view.isUserInteractionEnabled = false
-       
-        Kommunicate.createAndShowConversation(from: self, completion: {
-            error in
-            self.activityIndicator.stopAnimating()
-            self.view.isUserInteractionEnabled = true
-            if error != nil {
-                print("Error while launching")
+        
+        let kommunicateConversationBuilder = KMConversationBuilder()
+            .useLastConversation(true)
+        let conversation = kommunicateConversationBuilder.build()
+        let teamid = "67476167"
+
+        Kommunicate.createConversation(conversation: conversation) { (result) in
+            switch result {
+            case .success(let conversationId):
+                self.activityIndicator.stopAnimating()
+                self.view.isUserInteractionEnabled = true
+                DispatchQueue.main.async {
+                    Kommunicate.showConversationWith(groupId: conversationId, from: self, completionHandler: { success in
+                        guard success else {
+                            print("Failed to create show conversation")
+//                            completion(KommunicateError.conversationNotPresent)
+                            return
+                        }
+                        let teamid = "67476167"
+
+//
+                        Kommunicate.udpateTeamId(conversation: conversation, teamId: teamid){ (result) in
+                            switch result {
+                            case .success(let groupId):
+                                print("Successfully to udpated the team id \(groupId)")
+
+                            case.failure(_):
+                                print("Failed to udpate the team id")
+                            }
+
+                        }
+//
+                        print("Kommunicate: conversation was shown")
+//                        completion(nil)
+                    })
+                }
+            case .failure(_):
+//                completion(KommunicateError.conversationCreateFailed)
+                return
             }
-        })
+        }
+      
+//
+//        Kommunicate.createAndShowConversation(from: self, completion: {
+//            error in
+//            self.activityIndicator.stopAnimating()
+//            self.view.isUserInteractionEnabled = true
+//            if error != nil {
+//                print("Error while launching")
+//            }
+//        })
     }
     @IBAction func logoutAction(_ sender: Any) {
         Kommunicate.logoutUser { (result) in

--- a/Example/Kommunicate/ViewController.swift
+++ b/Example/Kommunicate/ViewController.swift
@@ -45,7 +45,7 @@ let teamid = "67476167"
                         let teamid = "67476167"
 
 //
-                        Kommunicate.udpateTeamId(conversation: conversation, teamId: teamid){ (result) in
+                        Kommunicate.updateTeamId(conversation: conversation, teamId: teamid){ (result) in
                             switch result {
                             case .success(let groupId):
                                 print("Successfully to udpated the team id \(groupId)")

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -388,6 +388,34 @@ open class Kommunicate: NSObject,Localizable, KMPreChatFormViewControllerDelegat
             }
         } else { completion(.failure(KommunicateError.teamNotPresent)) }
     }
+   
+    
+    /**
+     Updates the conversation teamid.
+     Requires the conversation  and the team ID to update
+
+     - Parameters:
+     - conversation: Conversation that needs to be updated
+     - teamId :  teamId that needs to be udpated in conversation
+
+     - completion: Called with the status of the Team ID update
+     */
+    open class func udpateTeamId(conversation: KMConversation,teamId: String, completion:@escaping (Result<String, KommunicateError>) -> ()) {
+        
+        let service = KMConversationService()
+        guard let groupID = conversation.clientConversationId, !groupID.isEmpty else { return }
+        if !teamId.isEmpty {
+            service.updateTeam(groupID: groupID, teamID: teamId) { response in
+                if (response.success) {
+                    completion(.success(groupID))
+                } else {
+                    completion(.failure(KommunicateError.conversationUpdateFailed))
+                }
+            }
+        } else { completion(.failure(KommunicateError.teamNotPresent)) }
+    }
+    
+    
 
     /**
      Generates a random id that can be used as an `userId`
@@ -661,6 +689,7 @@ open class Kommunicate: NSObject,Localizable, KMPreChatFormViewControllerDelegat
         }
     }
 
+
     private class func createAConversationAndLaunch(
         from viewController: UIViewController,
         completion:@escaping (_ error: KommunicateError?) -> ()) {
@@ -670,6 +699,8 @@ open class Kommunicate: NSObject,Localizable, KMPreChatFormViewControllerDelegat
         createConversation(conversation: conversation) { (result) in
             switch result {
             case .success(let conversationId):
+                let teamid = "67476167"
+                
                 DispatchQueue.main.async {
                     showConversationWith(groupId: conversationId, from: viewController, completionHandler: { success in
                         guard success else {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -400,19 +400,23 @@ open class Kommunicate: NSObject,Localizable, KMPreChatFormViewControllerDelegat
 
      - completion: Called with the status of the Team ID update
      */
-    open class func udpateTeamId(conversation: KMConversation,teamId: String, completion:@escaping (Result<String, KommunicateError>) -> ()) {
+    open class func updateTeamId(conversation: KMConversation,teamId: String, completion:@escaping (Result<String, KommunicateError>) -> ()) {
         
         let service = KMConversationService()
         guard let groupID = conversation.clientConversationId, !groupID.isEmpty else { return }
-        if !teamId.isEmpty {
-            service.updateTeam(groupID: groupID, teamID: teamId) { response in
-                if (response.success) {
-                    completion(.success(groupID))
-                } else {
-                    completion(.failure(KommunicateError.conversationUpdateFailed))
-                }
+       
+        guard !teamId.isEmpty else {
+            return completion(.failure(KommunicateError.teamNotPresent))
+        }
+        
+        service.updateTeam(groupID: groupID, teamID: teamId) { response in
+            if (response.success) {
+                completion(.success(groupID))
+            } else {
+                completion(.failure(KommunicateError.conversationUpdateFailed))
             }
-        } else { completion(.failure(KommunicateError.teamNotPresent)) }
+        }
+        
     }
     
     


### PR DESCRIPTION
## Summary
There is no option to update the team id of a conversation after the creation.We have added a method to achieve it. The parameters of the method  are conversation object & team id, method will update the conversation with the new team id.


## Testing
I have tested locally by calling the method the team updation happened successfully


Note :
I have changed some codes in view controller class to test this feature. Those changes will be removed once its tested.Please consider Kommunicate.swift  file changes for this PR.
