### PR TITLE
[CM-824] Set s3 service as the default service for upload/download images | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
+- [CM-842] Added S3 service as the default service for upload/download images
 - [CM-758] Added callback for User Online Status 
 - [CM-798] Launch Prechat with Custom Payload 
 

--- a/Example/Kommunicate/AppDelegate.swift
+++ b/Example/Kommunicate/AppDelegate.swift
@@ -15,7 +15,7 @@
         var window: UIWindow?
 
         // Pass your App Id here. You can get the App Id from install section in the dashboard.
-        var appId = "18ae6ce9d4f469f95c9c095fb5b0bda44"
+        var appId = ""
 
         func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
             setUpNavigationBarAppearance()

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -775,6 +775,7 @@ open class Kommunicate: NSObject, Localizable {
         ALUserDefaultsHandler.setDebugLogsRequire(true)
         ALApplozicSettings.setSwiftFramework(true)
         ALApplozicSettings.hideMessages(withMetadataKeys: ["KM_ASSIGN", "KM_STATUS"])
+        ALApplozicSettings.enableS3StorageService(true)
     }
 
     func setupDefaultStyle() {


### PR DESCRIPTION
## Summary
- Set S3 service as the default service for upload / download images.
## Note
A PR is filed already in KM Chat UI repo for this. [https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/pull/25](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/pull/25)
## Testing
Locally tested by pointing to the above PR branch.