### PR TITLE
[CM-870] oneTimeRating feature | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
+- [CM-870] Added OneTime Rating Feature
 - [CM-701] Added Bot Typing Indicator Support
 - [CM-699] Show rating same as web.
 - [CM-848] Added Localisation Support for the Last message of conversation which will be shown on ConversationList Screeen

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,6 +6,7 @@ platform :ios, '12.0'
 
 target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
+  pod 'KommunicateChatUI-iOS-SDK', :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :branch => 'Cm-870' 
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
     pod 'FBSnapshotTestCase' , '~> 2.1.4'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -33,6 +33,7 @@ PODS:
 DEPENDENCIES:
   - FBSnapshotTestCase (~> 2.1.4)
   - Kommunicate (from `../`)
+  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git`, branch `Cm-870`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -42,7 +43,6 @@ SPEC REPOS:
     - FBSnapshotTestCase
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateChatUI-iOS-SDK
     - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
@@ -52,6 +52,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Kommunicate:
     :path: "../"
+  KommunicateChatUI-iOS-SDK:
+    :branch: Cm-870
+    :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
+
+CHECKOUT OPTIONS:
+  KommunicateChatUI-iOS-SDK:
+    :commit: d48659f8c71aaf210c71860bdeef6d252a426233
+    :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
@@ -65,6 +73,6 @@ SPEC CHECKSUMS:
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: a825f9795795af36f76cb7b41dd61c0399c30e45
+PODFILE CHECKSUM: 99b6e4a9f0cc48b38824a0c3bbab70525a1cddfb
 
 COCOAPODS: 1.11.3

--- a/Sources/Kommunicate/Classes/Extensions/URLBuilder+ConversationFeedback.swift
+++ b/Sources/Kommunicate/Classes/Extensions/URLBuilder+ConversationFeedback.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension URLBuilder {
     static func feedbackURLFor(groupId: String) -> URLBuilder {
-        let url = URLBuilder.kommunicateApi.add(paths: ["rest", "ws", "feedback", groupId])
+        let url = URLBuilder.kommunicateApi.add(paths: ["feedback", groupId])
         return url
     }
 

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -520,6 +520,9 @@ extension KMConversationViewController {
                     self?.showRatingView()
                     return
                 }
+                guard !Kommunicate.defaultConfiguration.oneTimeRating else{
+                    return
+                }
                 self?.showRatingView()
             }
         }


### PR DESCRIPTION
## Summary
- Added oneTimeRating in ALK
- oneTimeRating = true -> Ask for feedback only once in a conversation
- oneTimeRating  = false -> Ask for feedback everytime the conversation is resolved.

## Note
- one more PR is there in KMChat UI repo: [PR]( https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/pull/33)

## Testing
- Locally test by pointing to the KMChat UI branch