### PR TITLE
[CM-956] Bitrise Test Case update & Use new account credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
+- [CM-956] UITestCases Optimization & bitrise updation 
 - [CM-945] Added support for setting default BotID, agentID, assignee and TeamID.Whenever customer creates a new conversation from Conversation List Screen by clicking `Create new Conversation` button , Conversation will be created based on this default settings.
 - [CM-829] Optimized Typing Indicator for Bot Messages & Added Typing Indicator for Welcome Message
 - [CM-918] Optimized Customisation -> Change message background color based on Primary color Selection on Dashboard

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -472,7 +472,6 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Kommunicate_Tests/Pods-Kommunicate_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
@@ -480,10 +479,10 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Kommunicate.xcodeproj/project.pbxproj
+++ b/Example/Kommunicate.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = C25JNDCBM4;
+						DevelopmentTeam = 932BY3Q6F7;
 						LastSwiftMigration = 1150;
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
@@ -730,14 +730,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Kommunicate_Example.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = C25JNDCBM4;
+				DEVELOPMENT_TEAM = 932BY3Q6F7;
 				INFOPLIST_FILE = Kommunicate/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Kommunicate.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = com.Kommunicate.demo;
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Sample App - Development";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -748,15 +748,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Kommunicate_Example.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = C25JNDCBM4;
+				DEVELOPMENT_TEAM = 932BY3Q6F7;
 				INFOPLIST_FILE = Kommunicate/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Kommunicate.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = com.Kommunicate.demo;
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Sample App - Distribution";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Example/Kommunicate/ViewController.swift
+++ b/Example/Kommunicate/ViewController.swift
@@ -22,18 +22,17 @@
         }
 
         @IBAction func launchConversation(_: Any) {
-//            activityIndicator.startAnimating()
-//            view.isUserInteractionEnabled = false
-//
-//            Kommunicate.createAndShowConversation(from: self, completion: {
-//                error in
-//                self.activityIndicator.stopAnimating()
-//                self.view.isUserInteractionEnabled = true
-//                if error != nil {
-//                    print("Error while launching")
-//                }
-//            })
-            Kommunicate.showConversations(from: self)
+            activityIndicator.startAnimating()
+            view.isUserInteractionEnabled = false
+
+            Kommunicate.createAndShowConversation(from: self, completion: {
+                error in
+                self.activityIndicator.stopAnimating()
+                self.view.isUserInteractionEnabled = true
+                if error != nil {
+                    print("Error while launching")
+                }
+            })
         }
 
         @IBAction func logoutAction(_: Any) {

--- a/Example/Kommunicate/ViewController.swift
+++ b/Example/Kommunicate/ViewController.swift
@@ -22,17 +22,18 @@
         }
 
         @IBAction func launchConversation(_: Any) {
-            activityIndicator.startAnimating()
-            view.isUserInteractionEnabled = false
-
-            Kommunicate.createAndShowConversation(from: self, completion: {
-                error in
-                self.activityIndicator.stopAnimating()
-                self.view.isUserInteractionEnabled = true
-                if error != nil {
-                    print("Error while launching")
-                }
-            })
+//            activityIndicator.startAnimating()
+//            view.isUserInteractionEnabled = false
+//
+//            Kommunicate.createAndShowConversation(from: self, completion: {
+//                error in
+//                self.activityIndicator.stopAnimating()
+//                self.view.isUserInteractionEnabled = true
+//                if error != nil {
+//                    print("Error while launching")
+//                }
+//            })
+            Kommunicate.showConversations(from: self)
         }
 
         @IBAction func logoutAction(_: Any) {

--- a/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
+++ b/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
@@ -91,7 +91,7 @@ class KommunicateCreateConversationAndSendMessagesTests: XCTestCase {
         let openLocation = app.buttons[InAppButton.ConversationScreen.openLocation]
         waitFor(object: openLocation) { $0.exists }
         openLocation.tap() // click on location button
-        sleep(5)
+        sleep(15)
         addUIInterruptionMonitor(withDescription: AppPermission.AlertMessage.accessLocation) { alerts -> Bool in
             if alerts.buttons[AppPermission.AlertButton.allowLoation].exists {
                 alerts.buttons[AppPermission.AlertButton.allowLoation].tap()

--- a/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
+++ b/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
@@ -19,6 +19,7 @@ class KommunicateCreateConversationAndSendMessagesTests: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+        sleep(15)
         addUIInterruptionMonitor(withDescription: AppPermission.AlertMessage.accessNotificationInApplication) { alerts -> Bool in
             if alerts.buttons[AppPermission.AlertButton.allow].exists {
                 alerts.buttons[AppPermission.AlertButton.allow].tap()

--- a/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
+++ b/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
@@ -19,7 +19,7 @@ class KommunicateCreateConversationAndSendMessagesTests: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        sleep(15)
+        sleep(10)
         addUIInterruptionMonitor(withDescription: AppPermission.AlertMessage.accessNotificationInApplication) { alerts -> Bool in
             if alerts.buttons[AppPermission.AlertButton.allow].exists {
                 alerts.buttons[AppPermission.AlertButton.allow].tap()

--- a/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
+++ b/Example/Kommunicate_ExampleUITests/KommunicateCreateConversationAndSendMessagesTests.swift
@@ -42,6 +42,7 @@ class KommunicateCreateConversationAndSendMessagesTests: XCTestCase {
         let openPhotos = app.buttons[InAppButton.ConversationScreen.openPhotos]
         waitFor(object: openPhotos) { $0.exists }
         app.buttons[InAppButton.ConversationScreen.openPhotos].tap() // Click on photo button
+        sleep(15)
         addUIInterruptionMonitor(withDescription: AppPermission.AlertMessage.accessPhoto) { alerts -> Bool in
             if alerts.buttons[AppPermission.AlertButton.allowAllPhotos].exists {
                 alerts.buttons[AppPermission.AlertButton.allowAllPhotos].tap()
@@ -68,6 +69,7 @@ class KommunicateCreateConversationAndSendMessagesTests: XCTestCase {
             app.buttons[InAppButton.ConversationScreen.openCamera]
         waitFor(object: openCamera) { $0.exists }
         app.buttons[InAppButton.ConversationScreen.openCamera].tap()
+        sleep(15)
         addUIInterruptionMonitor(withDescription: AppPermission.AlertMessage.accessPhoto) { alerts -> Bool in
             if alerts.buttons[AppPermission.AlertButton.allowAllPhotos].exists {
                 alerts.buttons[AppPermission.AlertButton.allowAllPhotos].tap()

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -9,7 +9,7 @@ target 'Kommunicate_Example' do
   pod 'KommunicateChatUI-iOS-SDK', :git => 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git', :branch => 'dev'
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
-    pod 'FBSnapshotTestCase' , '~> 2.1.4'
+    pod 'iOSSnapshotTestCase' , '~> 8.0.0'
     pod 'Nimble'
     pod 'Quick'
     pod 'Nimble-Snapshots'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,4 @@
 PODS:
-  - FBSnapshotTestCase (2.1.4):
-    - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
-  - FBSnapshotTestCase/Core (2.1.4)
-  - FBSnapshotTestCase/SwiftSupport (2.1.4):
-    - FBSnapshotTestCase/Core
   - iOSSnapshotTestCase (8.0.0):
     - iOSSnapshotTestCase/SwiftSupport (= 8.0.0)
   - iOSSnapshotTestCase/Core (8.0.0)
@@ -31,7 +26,7 @@ PODS:
   - SwipeCellKit (2.7.1)
 
 DEPENDENCIES:
-  - FBSnapshotTestCase (~> 2.1.4)
+  - iOSSnapshotTestCase (~> 8.0.0)
   - Kommunicate (from `../`)
   - KommunicateChatUI-iOS-SDK (from `https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git`, branch `dev`)
   - Nimble
@@ -40,7 +35,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - FBSnapshotTestCase
     - iOSSnapshotTestCase
     - Kingfisher
     - KommunicateCore-iOS-SDK
@@ -62,7 +56,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kingfisher: 5efc54fec3980f92354898532e562cc17f31efb4
   Kommunicate: b6a93db6b3e46e3a13a443e24cbacfa30eed91e8
@@ -73,6 +66,6 @@ SPEC CHECKSUMS:
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: 7cd271759f4396c54616cbae23e0540d7f7197e1
+PODFILE CHECKSUM: 71e9528497f8b4631a9d59677822ecd0231fef1c
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## Summary
- Updated bitrise Workflow steps versions
- Updated Snapshot test pods
- replaced certificates,provisional certificates, team id, bundle ids with new account.
- added time delays before interruption alerts