### PR TITLE
[CM-961] Blank message comes if handover option is added in welcome message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
+- [CM-961] Fixed Blank message comes if handover option is added in welcome message
 - [CM-956] UITestCases Optimization & bitrise updation 
 - [CM-945] Added support for setting default BotID, agentID, assignee and TeamID.Whenever customer creates a new conversation from Conversation List Screen by clicking `Create new Conversation` button , Conversation will be created based on this default settings.
 - [CM-829] Optimized Typing Indicator for Bot Messages & Added Typing Indicator for Welcome Message

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -791,7 +791,8 @@ open class Kommunicate: NSObject, Localizable {
         ALApplozicSettings.setFilterContactsStatus(true)
         ALUserDefaultsHandler.setDebugLogsRequire(true)
         ALApplozicSettings.setSwiftFramework(true)
-        ALApplozicSettings.hideMessages(withMetadataKeys: ["KM_ASSIGN", "KM_STATUS"])
+        let hiddenMessageMetaDataFlagArray = ["KM_ASSIGN", "KM_STATUS" , "KM_ASSIGN_TO", "KM_ASSIGN_TEAM"]
+        ALApplozicSettings.hideMessages(withMetadataKeys:hiddenMessageMetaDataFlagArray)
         ALApplozicSettings.enableS3StorageService(true)
     }
 


### PR DESCRIPTION
## Summary
- Empty Message is coming if handover option is added in welcome message.
<img width="385" alt="Screenshot 2022-06-15 at 5 01 54 PM" src="https://user-images.githubusercontent.com/61688116/174220067-856646b0-9ac6-4765-b0ee-114f45361f78.png">

## RootCause
- Extra message object is been added with only having metadata of `"KM_ASSIGN_TO" : "id"`.thatswhy empty message in showing on device side
- deviceside create new channel endpoint is older version when comparing to chat widget's

## Solution
- added `KM_ASSIGN,KM_ASSIGN_TO,KM_ASSIGN_TEAM` flags to hidden category & removing messages having those flags same like `"hide": true`

## Motivation
- Web chat widget following the same way of handling

## After fix

<img src = "https://user-images.githubusercontent.com/61688116/174220635-08a84ee5-0c7e-4a43-94ee-de2adbc2ca50.png" width = 250 height = 400 />
