### PR TITLE
[CM-977] Showing Bot Typing indicator for older conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
-
+- [CM-977] Fixed Showing Bot typing indicator when you open older conversations
 ## [6.7.0] - 2022-06-24Z
 - Updated KM Chat UI to 0.2.3
 - [CM-961] Fixed Blank message comes if handover option is added in welcome message

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -135,6 +135,8 @@ open class KMConversationViewController: ALKConversationViewController {
         guard let channelId = viewModel.channelKey else { return }
         sendConversationOpenNotification(channelId: String(describing: channelId))
         setupConversationClosedView()
+        delayInterval = KMAppUserDefaultHandler.shared.botMessageDelayInterval/1000
+        UserDefaults.standard.set((delayInterval), forKey: "botDelayInterval")
     }
 
     override open func viewDidLayoutSubviews() {
@@ -172,8 +174,6 @@ open class KMConversationViewController: ALKConversationViewController {
 
        let contactService = ALContactService()
        if viewModel.channelKey != nil, viewModel.channelKey == messageArray[count].groupId {
-           delayInterval = KMAppUserDefaultHandler.shared.botMessageDelayInterval/1000
-           UserDefaults.standard.set((delayInterval), forKey: "botDelayInterval")
            let alContact = contactService.loadContact(byKey: "userId", value:  messageArray[count].to)
             // Check for bot message & delay interval
            if delayInterval > 0 && alContact?.roleType == NSNumber.init(value: AL_BOT.rawValue){


### PR DESCRIPTION
## Summary
- This PR contains fix for mismatch of bot delay when you open the conversation for first time

There is another filed to fix the issue in KM Chat UI : https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/pull/43
