### PR TITLE
[CM-1167] Added custom bot name feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
-
+- [CM-1167] Added a feature Custom Bot Name on Conversation screen through chat context 
 ## [6.7.4] - 2022-11-02Z
 - Upgraded KommunicateChatUI-iOS-SDK to 0.2.7
 - [CM-1146] Fixed shared location preview issue by updating api key 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,8 @@ platform :ios, '12.0'
 
 target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
-  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :branch => 'cm-1167'
+  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git', :branch => 'dev'
+pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git', :branch => 'dev'
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
     pod 'iOSSnapshotTestCase' , '~> 8.0.0'

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,6 +6,7 @@ platform :ios, '12.0'
 
 target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
+  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :branch => 'cm-1167'
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
     pod 'iOSSnapshotTestCase' , '~> 8.0.0'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   KommunicateChatUI-iOS-SDK:
-    :commit: a8e7738d9b637156b6bd3782d1a26569653ca8f5
+    :commit: 456e2ce84b41d6a84832e7481a1029a69d167b93
     :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -28,6 +28,7 @@ PODS:
 DEPENDENCIES:
   - iOSSnapshotTestCase (~> 8.0.0)
   - Kommunicate (from `../`)
+  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git`, branch `cm-1167`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -36,7 +37,6 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateChatUI-iOS-SDK
     - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
@@ -46,6 +46,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Kommunicate:
     :path: "../"
+  KommunicateChatUI-iOS-SDK:
+    :branch: cm-1167
+    :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
+
+CHECKOUT OPTIONS:
+  KommunicateChatUI-iOS-SDK:
+    :commit: a8e7738d9b637156b6bd3782d1a26569653ca8f5
+    :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -58,6 +66,6 @@ SPEC CHECKSUMS:
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: 4ce9d42da4b992774ca3d9b09546e7c3e0c0e727
+PODFILE CHECKSUM: b3fe8a96e1632426e2f82a3baebbc83cafeb3fa2
 
 COCOAPODS: 1.11.3

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -28,7 +28,8 @@ PODS:
 DEPENDENCIES:
   - iOSSnapshotTestCase (~> 8.0.0)
   - Kommunicate (from `../`)
-  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git`, branch `cm-1167`)
+  - KommunicateChatUI-iOS-SDK (from `https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git`, branch `dev`)
+  - KommunicateCore-iOS-SDK (from `https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git`, branch `dev`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -37,7 +38,6 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
     - Quick
@@ -47,13 +47,19 @@ EXTERNAL SOURCES:
   Kommunicate:
     :path: "../"
   KommunicateChatUI-iOS-SDK:
-    :branch: cm-1167
-    :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
+    :branch: dev
+    :git: https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git
+  KommunicateCore-iOS-SDK:
+    :branch: dev
+    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
 
 CHECKOUT OPTIONS:
   KommunicateChatUI-iOS-SDK:
-    :commit: b9248c487e68fef95e4f6411913a1153b5a6b078
-    :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
+    :commit: 899320b0c2a38e7fb11b106ded0f720a611c1af0
+    :git: https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git
+  KommunicateCore-iOS-SDK:
+    :commit: edaaabb11251da7a01eb610bfa571f719717e293
+    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -66,6 +72,6 @@ SPEC CHECKSUMS:
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: b3fe8a96e1632426e2f82a3baebbc83cafeb3fa2
+PODFILE CHECKSUM: 4d4918cbd4b5fbeb645445faac7ab61d544ea9f7
 
 COCOAPODS: 1.11.3

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   KommunicateChatUI-iOS-SDK:
-    :commit: 456e2ce84b41d6a84832e7481a1029a69d167b93
+    :commit: 219be8db87e1dc8baca95eb3a59c8cacc0cde463
     :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   KommunicateChatUI-iOS-SDK:
-    :commit: 219be8db87e1dc8baca95eb3a59c8cacc0cde463
+    :commit: b9248c487e68fef95e4f6411913a1153b5a6b078
     :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:

--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -203,7 +203,7 @@ class ConversationVCNavBar: UIView, Localizable {
         } else {
             profileImage.image = placeHolderImage
         }
-        profileName.text = name
+        profileName.text = KMCellConfiguration.customBotName.isEmpty ? name : KMCellConfiguration.customBotName
     }
 
     private func placeHolderImage(channel: ALChannel) -> UIImage? {

--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -203,7 +203,7 @@ class ConversationVCNavBar: UIView, Localizable {
         } else {
             profileImage.image = placeHolderImage
         }
-        profileName.text = KMCellConfiguration.customBotName.isEmpty ? name : KMCellConfiguration.customBotName
+        profileName.text = name
     }
 
     private func placeHolderImage(channel: ALChannel) -> UIImage? {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -334,24 +334,7 @@ open class Kommunicate: NSObject, Localizable {
                 completionHandler(false)
                 return
             }
-            // Fetch Chat Context & check for custom bot name in it.If its present, update KMCellConfiguration.customBotName
-            do {
-                if let messageMetadata = channel.metadata as? [String: Any],
-                      let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,!jsonData.isEmpty,
-                      let data = jsonData.data(using: .utf8),
-                      let chatContextData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any],
-                   let customBot = chatContextData["bot_customization"] as? [String: String],
-                   let customBotName = customBot["name"],
-                   let customBotId = customBot["id"],
-                   !customBotName.isEmpty, !customBotId.isEmpty {
-                    ALMessage.customBotName = customBotName
-                    ALMessage.customizedBotId = customBotId
-                }
-            }
-            catch {
-                print("Failed to fetch custom bot name")
-            }
-            
+          
             self.openChatWith(
                 groupId: key,
                 from: viewController,

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -344,8 +344,8 @@ open class Kommunicate: NSObject, Localizable {
                    let customBotName = customBot["name"],
                    let customBotId = customBot["id"],
                    !customBotName.isEmpty, !customBotId.isEmpty {
-                    KMCellConfiguration.customBotName = customBotName
-                    KMCellConfiguration.customizedBotId = customBotId
+                    ALMessage.customBotName = customBotName
+                    ALMessage.customizedBotId = customBotId
                 }
             }
             catch {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -334,6 +334,20 @@ open class Kommunicate: NSObject, Localizable {
                 completionHandler(false)
                 return
             }
+            // Fetch Chat Context & check for custom bot name in it.If its present, update KMCellConfiguration.customBotName
+            do {
+                if let messageMetadata = channel.metadata as? [String: Any],
+                      let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,!jsonData.isEmpty,
+                      let data = jsonData.data(using: .utf8),
+                      let chatContextData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any],
+                   let customBotName = chatContextData["custom_bot_name"] as? String,
+                   !customBotName.isEmpty {
+                    KMCellConfiguration.customBotName = customBotName
+                }
+            }
+            catch {
+                print("Failed to fetch custom bot name")
+            }
             
             self.openChatWith(
                 groupId: key,

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -334,6 +334,28 @@ open class Kommunicate: NSObject, Localizable {
                 completionHandler(false)
                 return
             }
+            
+            // Fetch Chat Context & check for custom bot name in it.if its present then store it in local
+            do {
+                if let messageMetadata = channel.metadata as? [String: Any],
+                    let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,
+                    !jsonData.isEmpty,
+                    let data = jsonData.data(using: .utf8),
+                    let chatContextData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any],
+                    let customBot = chatContextData["bot_customization"] as? [String: String],
+                    let customBotName = customBot["name"],
+                    let customBotId = customBot["id"],
+                    !customBotName.isEmpty, !customBotId.isEmpty {
+                        ALApplozicSettings.setCustomBotName(customBotName)
+                        ALApplozicSettings.setCustomizedBotId(customBotId)
+                } else {
+                    ALApplozicSettings.clearCustomBotConfiguration()
+                }
+                
+            } catch {
+                print("Failed to fetch custom bot name")
+                ALApplozicSettings.clearCustomBotConfiguration()
+            }
           
             self.openChatWith(
                 groupId: key,

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -340,9 +340,12 @@ open class Kommunicate: NSObject, Localizable {
                       let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,!jsonData.isEmpty,
                       let data = jsonData.data(using: .utf8),
                       let chatContextData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any],
-                   let customBotName = chatContextData["custom_bot_name"] as? String,
-                   !customBotName.isEmpty {
+                   let customBot = chatContextData["bot_customization"] as? [String: String],
+                   let customBotName = customBot["name"],
+                   let customBotId = customBot["id"],
+                   !customBotName.isEmpty, !customBotId.isEmpty {
                     KMCellConfiguration.customBotName = customBotName
+                    KMCellConfiguration.customizedBotId = customBotId
                 }
             }
             catch {


### PR DESCRIPTION
## Summary
- Added way to change the bot name via chat context of conversation

## Note:
How to do it?
first update the chat context before creating the conversation like below
```
let messageInfo = ["bot_customization": ["id":"bot id to be customised","name":"custom name"]]
      do {
        try Kommunicate.defaultConfiguration.updateChatContext(with: messageInfo)
      } catch {
        print("Failed to update chat context: ", error)
      }
```

then in conversation you can see your customised bot name.