### PR TITLE
[CM-1191] Observe Zendesk Agent Events from dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
-- [CM-1217] Added Authentication Flow using jwt token for Zendesk 
-- [CM-1189] Added Zendesk Integration
+- Added Zendesk Integration
 - [CM-1167] Added a feature Custom Bot Name on Conversation screen through chat context 
 ## [6.7.4] - 2022-11-02Z
 - Upgraded KommunicateChatUI-iOS-SDK to 0.2.7

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,8 +6,8 @@ platform :ios, '12.0'
 
 target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
-  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :branch => 'CM-1217'
-pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git', :branch => 'CM-1217'
+  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :branch => 'CM-1191'
+pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git', :branch => 'CM-1191'
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
     pod 'iOSSnapshotTestCase' , '~> 8.0.0'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -41,8 +41,8 @@ PODS:
 DEPENDENCIES:
   - iOSSnapshotTestCase (~> 8.0.0)
   - Kommunicate (from `../`)
-  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git`, branch `CM-1217`)
-  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `CM-1217`)
+  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git`, branch `CM-1191`)
+  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `CM-1191`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -66,18 +66,18 @@ EXTERNAL SOURCES:
   Kommunicate:
     :path: "../"
   KommunicateChatUI-iOS-SDK:
-    :branch: CM-1217
+    :branch: CM-1191
     :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
   KommunicateCore-iOS-SDK:
-    :branch: CM-1217
+    :branch: CM-1191
     :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 CHECKOUT OPTIONS:
   KommunicateChatUI-iOS-SDK:
-    :commit: 2fe058eef2458a1f9488053eca1651408f98723d
+    :commit: 78e13bfbf0ea47323f6a91f4ef0700a97eecbf2f
     :git: https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git
   KommunicateCore-iOS-SDK:
-    :commit: 2ba1e0270f073e9422c51b970af6e5a42ed1e99f
+    :commit: bb02f7c179a0152c21c0a5eb8acb13e18509d0ac
     :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
@@ -97,6 +97,6 @@ SPEC CHECKSUMS:
   ZendeskMessagingSDK: 4f5f3d43766bb3b2ea6411d1331cfe609ff33618
   ZendeskSDKConfigurationsSDK: a5c21010e17b71d02bc2cfe73dcc9da1efa0a7b2
 
-PODFILE CHECKSUM: 2c19dd8d42956b0d3e71045166dc9eb7418060b0
+PODFILE CHECKSUM: 1fa8d187ce6580c1e17cce6cc0b01e2c57b98f2c
 
 COCOAPODS: 1.11.3

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -456,20 +456,14 @@ open class KMConversationViewController: ALKConversationViewController {
               switch result {
                case .success(let conversationId):
                   ALApplozicSettings.setLastZendeskConversationId(NSNumber(value: Int(conversationId) ?? 0))
+                  
                   let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: NSNumber(value: Int(conversationId) ?? 0), localizedStringFileName: Kommunicate.defaultConfiguration.localizedStringFileName, prefilledMessage: nil)
-                  // Update the viewmodel
-                  weakSelf.viewModel = convViewModel
-                  weakSelf.unsubscribingChannel()
-                  weakSelf.viewModel.contactId = nil
-                  weakSelf.viewModel.prefilledMessage = nil
-                  weakSelf.viewModel.channelKey = NSNumber(value: Int(conversationId) ?? 0)
-                  weakSelf.viewModel.conversationProxy = nil
-                  weakSelf.viewModel.delegate = self
-                  weakSelf.loadingFinished(error: nil)
-                  // refresh the viewcontroller after setting the viewmodel
-                  weakSelf.refreshViewController()
+                 // Update the View Model & refresh the View Controller
+                  weakSelf.updateViewModelAndRefreshViewController(convViewModel, conversationId: NSNumber(value: Int(conversationId) ?? 0))
                case .failure(let kmConversationError):
                   print("Failed to create a conversation: ", kmConversationError)
+                  weakSelf.loadingFinished(error: kmConversationError)
+
               }
           }
         }
@@ -485,6 +479,21 @@ open class KMConversationViewController: ALKConversationViewController {
             conversationClosedView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             conversationClosedView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+    }
+    
+    private func updateViewModelAndRefreshViewController(_ viewModel:ALKConversationViewModel, conversationId: NSNumber ) {
+        // Update the viewmodel
+        self.viewModel = viewModel
+        self.unsubscribingChannel()
+        self.viewModel.contactId = nil
+        self.viewModel.prefilledMessage = nil
+        self.viewModel.channelKey = conversationId
+        //NSNumber(value: Int(conversationId) ?? 0)
+        self.viewModel.conversationProxy = nil
+        self.viewModel.delegate = self
+        self.loadingFinished(error: nil)
+        // refresh the viewcontroller after setting the viewmodel
+        self.refreshViewController()
     }
 
     private func checkPlanAndShowSuspensionScreen() {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -199,7 +199,7 @@ open class Kommunicate: NSObject, Localizable {
         let applozicClient = applozicClientType.init(applicationKey: KMUserDefaultHandler.getApplicationKey())
         applozicClient?.logoutUser(completion: { error, _ in
             Kommunicate.shared.clearUserDefaults()
-            KMZendeskChatHandler.shared.disconnectFromZendesk()
+            KMZendeskChatHandler.shared.endChat()
             guard error == nil else {
                 completion(.failure(KMError.api(error)))
                 return
@@ -458,11 +458,11 @@ open class Kommunicate: NSObject, Localizable {
             completion(.zendeskKeyNotPresent)
             return
         }
-        
+
         guard let existingZendeskConversationId = ALApplozicSettings.getLastZendeskConversationId(),
               existingZendeskConversationId != 0 else {
-                zendeskHandler.initiateZendesk(key: accountKey)
                 zendeskHandler.resetConfiguration()
+                zendeskHandler.initiateZendesk(key: accountKey)
                 // If there is no existing conversation id then create a new conversation.
                 let kmConversation = KMConversationBuilder()
                               .useLastConversation(false)
@@ -490,8 +490,9 @@ open class Kommunicate: NSObject, Localizable {
               }
             return
         }
+        
         // Update group id so that messages can be fetched & stored locally
-        zendeskHandler.setGroupIdAndUpdateLastMessageCreatedTime(existingZendeskConversationId.stringValue)
+        zendeskHandler.setGroupId(existingZendeskConversationId.stringValue)
 
         guard let channel = ALChannelService().getChannelByKey(existingZendeskConversationId)  else {
             completion(.conversationNotPresent)
@@ -501,9 +502,9 @@ open class Kommunicate: NSObject, Localizable {
         if let assignee = channel.assigneeUserId, !assignee.isEmpty,
            let contact = ALContactService().loadContact(byKey: "userId", value: assignee) {
             if contact.roleType == NSNumber.init(value: AL_BOT.rawValue) {
-              zendeskHandler.updateHandoff(false)
+              zendeskHandler.updateHandoffFlag(false)
           } else {
-              zendeskHandler.updateHandoff(true)
+              zendeskHandler.updateHandoffFlag(true)
           }
         }
         
@@ -513,6 +514,7 @@ open class Kommunicate: NSObject, Localizable {
             bool == true ? completion(nil) : completion(.conversationOpenFailed)
             print("Opening Existing conversation which is assigned to BOT")
         })
+        
     }
     
     /**

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -514,7 +514,6 @@ open class Kommunicate: NSObject, Localizable {
             bool == true ? completion(nil) : completion(.conversationOpenFailed)
             print("Opening Existing conversation which is assigned to BOT")
         })
-        
     }
     
     /**


### PR DESCRIPTION
## Summary
- Observe events -> message, attachment message, agent leave
- Added chat log logic to sync zendesk and kommunicate messages

## Tasks completed:
- When message event triggered, send message to /rest/ws/zendesk/message/send
- When attachment event triggered, send attachment to /rest/ws/zendesk/file/send
- When Agent ends chat from Zendesk, call Resolve conversation API and resolve the conversation.
- When "Restart conversation" is clicked, a new conversation is created to maintain a single chat thread.
- Handled Chat logs -> If the app is closed and opened again, it will sync the messages sent from Zendesk dashboard until session is live