### PR TITLE
[CM-1308] Added customisation for restart conversation button

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,6 +6,8 @@ platform :ios, '12.0'
 
 target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
+  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git', :branch => 'CM-1308'
+
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
     pod 'iOSSnapshotTestCase' , '~> 8.0.0'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -41,6 +41,7 @@ PODS:
 DEPENDENCIES:
   - iOSSnapshotTestCase (~> 8.0.0)
   - Kommunicate (from `../`)
+  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git`, branch `CM-1308`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -49,7 +50,6 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateChatUI-iOS-SDK
     - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
@@ -65,6 +65,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Kommunicate:
     :path: "../"
+  KommunicateChatUI-iOS-SDK:
+    :branch: CM-1308
+    :git: https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git
+
+CHECKOUT OPTIONS:
+  KommunicateChatUI-iOS-SDK:
+    :commit: abe45f00ffb3c06bf911e5ac3ca3aebb581f00ad
+    :git: https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -83,6 +91,6 @@ SPEC CHECKSUMS:
   ZendeskMessagingSDK: 4f5f3d43766bb3b2ea6411d1331cfe609ff33618
   ZendeskSDKConfigurationsSDK: a5c21010e17b71d02bc2cfe73dcc9da1efa0a7b2
 
-PODFILE CHECKSUM: 4ce9d42da4b992774ca3d9b09546e7c3e0c0e727
+PODFILE CHECKSUM: ca537c50529ff2ecdc894bec7de603ecdaadfbce
 
 COCOAPODS: 1.11.3

--- a/Sources/Kommunicate/Classes/Views/ConversationClosedView.swift
+++ b/Sources/Kommunicate/Classes/Views/ConversationClosedView.swift
@@ -41,6 +41,7 @@ class ConversationClosedView: UIView {
         button.setTitleColor(.text(.warmBlue), for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(LocalizedText.restartConversation, for: .normal)
+        button.isHidden = Kommunicate.defaultConfiguration.hideRestartConversationButton
         return button
     }()
 


### PR DESCRIPTION
## Summary
- Added customisation to visibility of restart conversation button on conversation screen. 
- This restart conversation button will be shown to end user once conversation gets resolved. By clicking this button user can restart the conversation.
- Now we can show/hide this button. By default it will be shown.

## Images
<img src = "https://user-images.githubusercontent.com/121929127/217205895-5b575029-1100-430f-95a3-7e4ee3816866.png" width = 250 height = 500 />  <img src = "https://user-images.githubusercontent.com/121929127/217205905-82e22744-2cf0-47b9-8a8c-c4ebef28604a.png" width = 250 height = 500 />




