### PR TITLE
[CM-1302] Added customisation for back button on conversation list screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
-
+## [Unreleased]
+- [CM-1302] Added customization for back button on conversation list screen
 ## [6.7.7] 2023-01-31
 - Added function to unsubscribe to Chat Events
 - [CM-1280] Added Support for Create conversation Button on Conversation List Scren

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,6 +6,7 @@ platform :ios, '12.0'
 
 target 'Kommunicate_Example' do
   pod 'Kommunicate', :path => '../'
+  pod 'KommunicateChatUI-iOS-SDK' , :git => 'https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git', :branch => 'CM-1302'
   target 'Kommunicate_Tests' do
     inherit! :search_paths 
     pod 'iOSSnapshotTestCase' , '~> 8.0.0'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -41,6 +41,7 @@ PODS:
 DEPENDENCIES:
   - iOSSnapshotTestCase (~> 8.0.0)
   - Kommunicate (from `../`)
+  - KommunicateChatUI-iOS-SDK (from `https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git`, branch `CM-1302`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -49,7 +50,6 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateChatUI-iOS-SDK
     - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
@@ -65,6 +65,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Kommunicate:
     :path: "../"
+  KommunicateChatUI-iOS-SDK:
+    :branch: CM-1302
+    :git: https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git
+
+CHECKOUT OPTIONS:
+  KommunicateChatUI-iOS-SDK:
+    :commit: 75d5c8074589ee8da80ffef7cfe010ef79013cff
+    :git: https://github.com/Sathyan-KM/KommunicateChatUI-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -83,6 +91,6 @@ SPEC CHECKSUMS:
   ZendeskMessagingSDK: 4f5f3d43766bb3b2ea6411d1331cfe609ff33618
   ZendeskSDKConfigurationsSDK: a5c21010e17b71d02bc2cfe73dcc9da1efa0a7b2
 
-PODFILE CHECKSUM: 4ce9d42da4b992774ca3d9b09546e7c3e0c0e727
+PODFILE CHECKSUM: 1c1e25c6fd899e06c277030d9925649c5240cd45
 
 COCOAPODS: 1.11.3

--- a/Sources/Kommunicate/Classes/Extensions/UIViewController+Extension.swift
+++ b/Sources/Kommunicate/Classes/Extensions/UIViewController+Extension.swift
@@ -78,4 +78,16 @@ extension UIViewController {
 
         return rootViewController
     }
+    
+    public func getBackTextButton(title: String,target:Any, action: Selector) -> UIBarButtonItem {
+           return  UIBarButtonItem(title: title, style: .plain, target: target, action: action)
+    }
+    
+    public func getBackArrowButton(target:Any, action: Selector) -> UIBarButtonItem {
+        var backImage = UIImage(named: "icon_back", in: Bundle.kommunicate, compatibleWith: nil)
+        backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
+        let backButton = UIBarButtonItem(image: backImage, style: .plain, target: target, action: action)
+        backButton.accessibilityIdentifier = "BackButton"
+        return backButton
+    }
 }

--- a/Sources/Kommunicate/Classes/FaqViewController.swift
+++ b/Sources/Kommunicate/Classes/FaqViewController.swift
@@ -41,11 +41,7 @@ public class FaqViewController: UIViewController, Localizable {
 
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        var backImage = UIImage(named: "icon_back", in: Bundle.kommunicate, compatibleWith: nil)
-        backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
-        let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(backTapped))
-        backButton.accessibilityIdentifier = "BackButton"
-        navigationItem.leftBarButtonItem = backButton
+        navigationItem.leftBarButtonItem = getBackArrowButton(target: self, action: #selector(backTapped))
         navigationItem.title = localizedString(forKey: "FaqTitle", fileName: configuration.localizedStringFileName)
     }
 

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -344,16 +344,11 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
 
     func setupBackButton() {
         guard !configuration.hideBackButtonInConversationList else { return }
+        
         if configuration.enableBackArrowOnConversationListScreen {
-            var backImage = UIImage(named: "icon_back", in: Bundle.kommunicate, compatibleWith: nil)
-            backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
-            let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(customBackAction))
-            backButton.accessibilityIdentifier = "BackButton"
-            navigationItem.leftBarButtonItem = backButton
+            navigationItem.leftBarButtonItem = getBackArrowButton(target: self, action: #selector(customBackAction))
         } else {
-            let back = LocalizedText.leftBarBackButtonText
-            let leftBarButtonItem = UIBarButtonItem(title: back, style: .plain, target: self, action: #selector(customBackAction))
-            navigationItem.leftBarButtonItem = leftBarButtonItem
+            navigationItem.leftBarButtonItem = getBackTextButton(title: LocalizedText.leftBarBackButtonText, target: self, action: #selector(customBackAction))
         }
     }
 

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -343,11 +343,16 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
     }
 
     func setupBackButton() {
-        let back = LocalizedText.leftBarBackButtonText
-
-        let leftBarButtonItem = UIBarButtonItem(title: back, style: .plain, target: self, action: #selector(customBackAction))
-
-        if !configuration.hideBackButtonInConversationList {
+        guard !configuration.hideBackButtonInConversationList else { return }
+        if configuration.enableBackArrowOnConversationListScreen {
+            var backImage = UIImage(named: "icon_back", in: Bundle.kommunicate, compatibleWith: nil)
+            backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
+            let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(customBackAction))
+            backButton.accessibilityIdentifier = "BackButton"
+            navigationItem.leftBarButtonItem = backButton
+        } else {
+            let back = LocalizedText.leftBarBackButtonText
+            let leftBarButtonItem = UIBarButtonItem(title: back, style: .plain, target: self, action: #selector(customBackAction))
             navigationItem.leftBarButtonItem = leftBarButtonItem
         }
     }


### PR DESCRIPTION
## Summary
- Added customisation for back button on conversation list screen
- By default it will be arrow.You can customise the by following code
` Kommunicate.defaultConfiguration.enableBackArrowOnConversationListScreen = false/true
`

## Ref Images:
<img src="https://user-images.githubusercontent.com/121929127/217247948-ce785d8f-19d7-4988-a553-4456ba1bc3ac.png" width = 250 height = 500 /> <img src="https://user-images.githubusercontent.com/121929127/217247964-4b97b174-94ce-4570-85de-b83d688923c3.png" width = 250 height = 500 />
