### PR TITLE
Fixed default localisation text issue for start new conversation  button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## [Unreleased]
+- Fixed localisation text issue for Start New conversation Button on Conversation list screen.
 ## [6.7.7] 2023-01-31
 - Added function to unsubscribe to Chat Events
 - [CM-1280] Added Support for Create conversation Button on Conversation List Scren

--- a/Sources/Resources/Assets/Localizable.strings
+++ b/Sources/Resources/Assets/Localizable.strings
@@ -91,3 +91,5 @@ BotCharLimit = "Keep your message within %01d characters to help the bot underst
 RemoveCharMessage = "Remove %01d characters";
 RemainingCharMessage = "%01d characters remaining";
 CharLimit = "Keep your message within %01d characters | ( %@ )";
+/* Start New Conversation*/
+StartNewConversationButtonTitle = "Start New Conversation";


### PR DESCRIPTION
## Summary
- Fixed default localisation text issue for bottom start new conversation button. Customers can customize this on their project by using this flag `StartNewConversationButtonTitle`