### PR TITLE
Restart conversation button customization bug fix

### DIFF
--- a/Sources/Kommunicate/Classes/Views/ConversationClosedView.swift
+++ b/Sources/Kommunicate/Classes/Views/ConversationClosedView.swift
@@ -31,6 +31,7 @@ class ConversationClosedView: UIView {
         label.backgroundColor = .clear
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = LocalizedText.otherQueries
+        label.isHidden = Kommunicate.defaultConfiguration.hideRestartConversationButton
         return label
     }()
 


### PR DESCRIPTION
## Summary
- hidden  `Have other queries?` label when restart conversation button is hidden


## SS
### before fix

<img src="https://user-images.githubusercontent.com/121929127/219366127-41a875f0-1eb1-491e-8e12-56ff6be02e87.png" width="250" height="400" />

### after fix

<img src="https://user-images.githubusercontent.com/121929127/219366107-c7d31615-2977-4dcc-b856-21a479c53389.png" width="250" height="400" />

