### PR TITLE
[CM-1355] Added Customisation to hide chat widget on helpcenter page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
-## [6.7.9] 2023-02-22
+
+## [Unreleased]
+- Added customization for hidding Chat Widget on Helpcenter (FAQ) Page 
+## [6.8.0] 2023-02-22
 - Fixed Auto logout issue and setting client conversation key issue 
 ## [6.7.9] 2023-02-17
 - Fixed attempt to insert section 1 but there are only 1 sections after the update crash

--- a/Sources/Kommunicate/Classes/Extensions/URLBuilder+Faq.swift
+++ b/Sources/Kommunicate/Classes/Extensions/URLBuilder+Faq.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension URLBuilder {
-    static func faqURL(for applicationKey: String) -> URLBuilder {
-        return URLBuilder.helpcenterApi.add(item: "appId", value: applicationKey)
+    static func faqURL(for applicationKey: String, hideChat : Bool) -> URLBuilder {
+        return URLBuilder.helpcenterApi.add(item: "appId", value: applicationKey).add(item: "hideChat", value: hideChat)
     }
 }

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -660,7 +660,7 @@ open class Kommunicate: NSObject, Localizable {
     }
 
     open class func openFaq(from vc: UIViewController, with configuration: ALKConfiguration) {
-        guard let url = URLBuilder.faqURL(for: ALUserDefaultsHandler.getApplicationKey()).url else {
+        guard let url = URLBuilder.faqURL(for: ALUserDefaultsHandler.getApplicationKey(), hideChat: configuration.hideChatInHelpcenter).url else {
             return
         }
         let faqVC = FaqViewController(url: url, configuration: configuration)

--- a/Sources/Kommunicate/Classes/Utilities/KmConfigurationSetter.swift
+++ b/Sources/Kommunicate/Classes/Utilities/KmConfigurationSetter.swift
@@ -113,6 +113,10 @@ public class KMConfigurationSetter {
                 Kommunicate.defaultConfiguration.hideBottomStartNewConversationButton = !showStartNewConversation
             }
             
+            if let hideChatInHelpCenter = settingDict["hideChatInHelpcenter"] as? Bool {
+                Kommunicate.defaultConfiguration.hideChatInHelpcenter = hideChatInHelpCenter
+            }
+            
         } catch let error as NSError {
             print("Failed to read setting json string \(error.description)")
             return false


### PR DESCRIPTION
## Summary
- Added customisation flag to hide/show chat widget on helpcenter(FAQ) page
- Added this customisation for React Native (read settings from string)

### Note
- Linked PR: https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/pull/95