### PR TITLE
[CM-1535] Added Pass Group Creation URL 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Added Pass Group Creation URL
+
 ## [6.9.4] 2023-07-10
 - Fixed hideEmptyStateStartNewButtonInConversationList customization bug
 - Added Cusotmization for Start New Conversaion Button on Conversation List Screen

--- a/Sources/Kommunicate/Classes/KMConversation.swift
+++ b/Sources/Kommunicate/Classes/KMConversation.swift
@@ -22,9 +22,17 @@ import KommunicateCore_iOS_SDK
     public var conversationAssignee: String?
     public var teamId: String?
     public var defaultConversationAssignee: String?
+    public var appName: String? = Bundle.main.displayName
 
     public init(userId: String) {
         self.userId = userId
+    }
+}
+
+///  this is used to retrieve the name of the application. It's used in sending the metadata of Group Creation URL
+extension Bundle {
+    var displayName: String? {
+        return object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
     }
 }
 

--- a/Sources/Kommunicate/Classes/KMConversation.swift
+++ b/Sources/Kommunicate/Classes/KMConversation.swift
@@ -29,13 +29,6 @@ import KommunicateCore_iOS_SDK
     }
 }
 
-///  this is used to retrieve the name of the application. It's used in sending the metadata of Group Creation URL
-extension Bundle {
-    var displayName: String? {
-        return object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
-    }
-}
-
 /// KMConversationBuilder is used for building KMConversation object
 @objc public class KMConversationBuilder: NSObject {
     private var conversation = KMConversation(userId: KMUserDefaultHandler.getUserId() ?? Kommunicate.randomId())
@@ -131,5 +124,12 @@ extension Bundle {
     /// Finally call the build method on the KMConversationBuilder to build the KMConversation
     @objc public func build() -> KMConversation {
         return conversation
+    }
+}
+
+///  This extension is used to retrieve the name of the application. It's employed in sending the metadata of origin name, helping to identify the application being used.
+extension Bundle {
+    var displayName: String? {
+        return object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
     }
 }

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -18,6 +18,7 @@ public enum ChannelMetadataKeys {
     static let languageTag = "kmUserLanguageCode"
     static let teamId = "KM_TEAM_ID"
     static let conversationMetaData = "conversationMetadata" // dictionary mapped with this key will be shown on  ConversationInfo section
+    static let groupCreationURL = "GROUP_CREATION_URL"
 }
 
 enum LocalizationKey {
@@ -345,6 +346,16 @@ public class KMConversationService: KMConservationServiceable, Localizable {
 
         if let teamId = conversation.teamId, !teamId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             metadata.setValue(teamId, forKey: ChannelMetadataKeys.teamId)
+        }
+        
+        if let appName = conversation.appName {
+            let label = "iOS: \(appName)"
+            metadata.setValue(label, forKey: ChannelMetadataKeys.groupCreationURL)
+        } else {
+            if let appID = KMUserDefaultHandler.getApplicationKey(){
+                let label = "iOS: \(appID)"
+                metadata.setValue(label, forKey: ChannelMetadataKeys.groupCreationURL)
+            }
         }
 
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -349,13 +349,11 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         }
         
         if let appName = conversation.appName {
-            let label = "iOS: \(appName)"
-            metadata.setValue(label, forKey: ChannelMetadataKeys.groupCreationURL)
-        } else {
-            if let appID = KMUserDefaultHandler.getApplicationKey(){
-                let label = "iOS: \(appID)"
-                metadata.setValue(label, forKey: ChannelMetadataKeys.groupCreationURL)
-            }
+            let originName = "iOS: " + appName
+            metadata.setValue(originName, forKey: ChannelMetadataKeys.groupCreationURL)
+        } else if let appID = KMUserDefaultHandler.getApplicationKey(){
+            let originName = "iOS: " + appID
+            metadata.setValue(originName, forKey: ChannelMetadataKeys.groupCreationURL)
         }
 
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -312,6 +312,16 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         }
         return newClientId
     }
+    
+    /// To check whether the app name does not contain only spaces.
+    func isValidAppName(_ checkString: String?) -> Bool {
+        guard let checkString = checkString else {
+            return false // App name is nil
+        }
+        
+        let trimmedString = checkString.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmedString.isEmpty
+    }
 
     func getMetaDataWith(_ conversation: KMConversation) -> NSMutableDictionary {
         let metadata = NSMutableDictionary(
@@ -348,10 +358,10 @@ public class KMConversationService: KMConservationServiceable, Localizable {
             metadata.setValue(teamId, forKey: ChannelMetadataKeys.teamId)
         }
         
-        if let appName = conversation.appName {
+        if let appName = conversation.appName, isValidAppName(appName) {
             let originName = "iOS: " + appName
             metadata.setValue(originName, forKey: ChannelMetadataKeys.groupCreationURL)
-        } else if let appID = KMUserDefaultHandler.getApplicationKey(){
+        } else if let appID = KMUserDefaultHandler.getApplicationKey() {
             let originName = "iOS: " + appID
             metadata.setValue(originName, forKey: ChannelMetadataKeys.groupCreationURL)
         }


### PR DESCRIPTION
## Summary
- Passed app name in the GROUP_CREATION_URL
- "GROUP_CREATION_URL": "iOS: <app_name>"
- if App Name is not available then AppID is passed

## Preview
<img width="310" alt="Screenshot 2023-07-19 at 7 02 52 PM" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/4c258b91-ebae-45f3-92c7-df4e91e6c7ff"> 
<img width="310" alt="Screenshot 2023-07-19 at 7 01 47 PM" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/9acd17db-8079-4163-94ed-84bc7299ec8f">
