### PR TITLE
Fixed converstation restart happening through message template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+##Unreleased
+- Fixed conversation restarting through user end via message templates even when restart conversation button is disabled
+
 ## [6.9.4] 2023-07-10
 - Fixed hideEmptyStateStartNewButtonInConversationList customization bug
 - Added Cusotmization for Start New Conversaion Button on Conversation List Screen

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -96,6 +96,8 @@ open class KMConversationViewController: ALKConversationViewController {
 
     private var isClosedConversationViewHidden = true {
         didSet {
+            // if the ClosedConversationView and restartConversationButton are hidden hide the message template view
+            templateView?.isHidden = !isClosedConversationViewHidden && configuration.hideRestartConversationButton
             guard oldValue != isClosedConversationViewHidden else { return }
             showClosedConversationView(!isClosedConversationViewHidden)
         }


### PR DESCRIPTION
## Summary
Fixed converstation restart happening through message template even when the restart conversation button is disabled

## Testing
- Add a `message_template.json` file inside `Examples for kommunicate` , dummy data is given below :

```
{
    "templates": [{
        "identifier":"1",
        "text":"Main Menu",
        "messageToSend": "button",
    },{
        "identifier":"2",
        "text":"Human",
        "messageToSend": "Handoff",
    }
    ]
}
```

- Resolve the conversation from dashboard and enable the restart conversation button from `ALKConversation.swift` `hideRestartConversationButton` . Build the app and in this case the message templates should not be shown so that the user should not be able to restart the conversation when he is not allowed to restart it.

**Older scenario** ->

![Simulator Screenshot - iPhone 14 Pro - 2023-07-20 at 13 58 45](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/598eba3b-5ddb-44a6-8592-1fa9c6b78b25)

**Fixed scenario** ->

![Simulator Screenshot - iPhone 14 Pro - 2023-07-20 at 14 01 07](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/5e91c2ec-fcd5-45cc-b82f-ceec8624d7f2)
