### PR TITLE
Fixed agent online/offline status when conversation is opened from conversation list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+##Unreleased
+- Fixed agent status not updating realtime when conversation is opened from conversation list
+
 ## [6.9.5] 2023-07-21
 - Added feature for sending metadata with origin name, including information on iOS device, facilitating identification of app name and user's device type.
 - Fixed the form submission with empty fields issue

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -650,6 +650,11 @@ extension KMConversationListViewController: ALMQTTConversationDelegate {
     }
     
     public func userOnlineStatusChanged(_ contactId: String!, status: String!) {
+        guard let viewcontroller = navigationController?.visibleViewController as? KMConversationViewController else {
+               print("Unable to update agent online status : No KMConversationViewController available")
+               return
+              }
+        viewcontroller.updateAssigneeOnlineStatus(userId: contactId)
     }
 
     open func updateUserDetail(_ userId: String!) {


### PR DESCRIPTION
## Summary
Fixed agent status not updating in real time when the conversation is opened from conversations list

## Testing
- Pull this branch
- Open X Code and build your app
- Agent online/offline status should be updating in real time when the conversation is opened from conversation list