### PR TITLE
[CM-1571] Fixed the Submit button cutting issue in the rating bar and increased the height of comment section in rating bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed the Submit Button cuting issue on rating bar.
+- Increased the size of Comment section in rating bar.
+
 ## [6.9.5] 2023-07-21
 - Added feature for sending metadata with origin name, including information on iOS device, facilitating identification of app name and user's device type.
 - Fixed the form submission with empty fields issue

--- a/Sources/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Sources/Kommunicate/Classes/Views/RatingViewController.swift
@@ -165,6 +165,7 @@ class RatingViewController: UIViewController {
             ratingViewHeightConstraint,
             commentsViewHeightConstraint,
             submitButtonHeightConstraint,
+            submitButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -(Size.SubmitButton.height)),
             titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             titleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: Size.TitleLabel.top),
         ])
@@ -360,7 +361,7 @@ private extension RatingViewController {
 
         enum CommentsView {
             static let top: CGFloat = 30.0
-            static let height: CGFloat = 80.0
+            static let height: CGFloat = 120.0
         }
     }
 }


### PR DESCRIPTION
## Summary

- Added Bottom Anchor Constraint for the Submit Button.
- Increased the height of Comment Section from 80.0 to 120.0 . 

## Without Changes

> ![Simulator Screenshot - iPhone SE (2nd generation) - 2023-08-03 at 09 24 31](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/c4bd06cd-a0b1-42d5-b573-205b1e6eeb85)

> iPhone SE (2nd generation)

> ![Simulator Screenshot - SampleAppTesting - 2023-08-03 at 09 23 38](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/8eb9c3b7-040b-4698-ad40-39e3d3d03a52)

> iPhone 14 Pro Max


## With Changes

> ![Simulator Screenshot - iPhone SE (2nd generation) - 2023-08-02 at 19 39 40](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/96fc9dd7-b89b-4b4a-9d90-3b8ac74de8e6)

> iPhone SE (2nd generation)



> ![Simulator Screenshot - SampleAppTesting - 2023-08-02 at 19 39 55](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/868f9bf2-474a-400f-8d4d-51534853f90e)

> iPhone 14 Pro Max
 