### PR TITLE
[CM-1593] Fixed Away Message & Rating message overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
 
+## Unreleased
+- Fixed Away Message & Rating message overlapping
+
 ## [6.9.7] 2023-08-11
 - Improved UI of multiple language selection & make it similar to android
 - Refresh Icon Change

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -469,6 +469,7 @@ open class KMConversationViewController: ALKConversationViewController {
                 return
             }
             weakSelf.isClosedConversationViewHidden = true
+            self?.awayMessageView.isHidden = false
             
             if let channelId = weakSelf.viewModel.channelKey {
                 KMCustomEventHandler.shared.publish(triggeredEvent: CustomEvent.restartConversationClick, data: ["conversationId":channelId])
@@ -639,6 +640,7 @@ extension KMConversationViewController {
         chatBar.clear()
         conversationClosedView.clearFeedback()
         isClosedConversationViewHidden = false
+        awayMessageView.isHidden = true
         let isCSATEnabled =
             !kmConversationViewConfiguration.isCSATOptionDisabled && userDefaults.isCSATEnabled
         guard let channelId = viewModel.channelKey, isCSATEnabled else { return }

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -736,7 +736,7 @@ extension KMConversationViewController {
 
     private func showClosedConversationView(_ flag: Bool) {
         conversationClosedView.isHidden = !flag
-        isAwayMessageViewHidden = true
+        isAwayMessageViewHidden = !flag
         updateMessageListBottomPadding(isClosedViewHidden: !flag)
         topConstraintClosedView?.isActive = flag
     }

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -150,6 +150,7 @@ open class KMConversationViewController: ALKConversationViewController {
         hideAwayAndClosedView()
         isConversationAssignedToDialogflowBot = false
         isChatBarHidden = false
+        awayMessageView.isHidden = false
     }
 
     override open func newMessagesAdded() {


### PR DESCRIPTION
## Summary

- Hided the away message while the conversation is resolved.
## Images

<img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/b7837998-9d1f-44dc-8c01-836a9639b645' width = 200 height = 400 /> <img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/4bd02148-8781-44d7-90e2-73dd6955d3bf' width = 200 height = 400 />

