### PR TITLE
[CM-1594] Fixed Keyboard overlapping on the Ratting Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed keyboard overlapping in Rating Screen.
 
 ## [6.9.7] 2023-08-11
 - Improved UI of multiple language selection & make it similar to android

--- a/Sources/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Sources/Kommunicate/Classes/Views/RatingViewController.swift
@@ -165,7 +165,7 @@ class RatingViewController: UIViewController {
             ratingViewHeightConstraint,
             commentsViewHeightConstraint,
             submitButtonHeightConstraint,
-            submitButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -(Size.SubmitButton.height)),
+            submitButton.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor, constant: -(Size.SubmitButton.height)),
             titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             titleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: Size.TitleLabel.top),
         ])


### PR DESCRIPTION
## Summary

- Removed the fixed constraint from the Submit Button. 

## Image 

- iPhone 14 Pro Max

<img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/928c2e37-6b28-47bf-b0a1-24d80c66eb57' width = 200 height = 400 /> <img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/0e5003bb-b8b1-4b93-b2bb-34d7c297b868' width = 200 height = 400 />


- iPhone SE 2nd Gen

<img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/d46bd5e7-c3c4-4103-9fc4-da4f38472101' width = 200 height = 400 /> <img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/4c475e6e-5a96-463d-a643-cfd615164548' width = 200 height = 400 />


