### PR TITLE
[CM-1391] Passed languageCode in groupMetadata and messageMetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Passed languageCode in groupMetadata and messageMetaData
+
 ## [6.9.8] 2023-08-23
 - Fixed keyboard overlapping in Rating Screen.
 - Fixed Away Message & Rating message overlapping

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -367,16 +367,13 @@ public class KMConversationService: KMConservationServiceable, Localizable {
             metadata.setValue(originName, forKey: ChannelMetadataKeys.groupCreationURL)
         }
         
-        do {
-            let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
-            let languageDict = [ChannelMetadataKeys.kmUserLocale : languageCode]
-            let messageInfoData = try JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted)
-            let messageInfoString = String(data: messageInfoData, encoding: .utf8) ?? ""
-            metadata[ChannelMetadataKeys.chatContext] = messageInfoString
-        } catch {
-            print("error while setting group metadata : \(error.localizedDescription)")
-        }
+        let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
+        let languageDict = [ChannelMetadataKeys.kmUserLocale : languageCode]
         
+        if let messageInfoData = try? JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted) {
+            let messageInfoString = String(data: messageInfoData, encoding: .utf8)
+            metadata[ChannelMetadataKeys.chatContext] = messageInfoString
+        }
 
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,
               !messageMetadata.isEmpty

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -370,8 +370,8 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
         let languageDict = [ChannelMetadataKeys.kmUserLocale : languageCode]
         
-        if let messageInfoData = try? JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted) {
-            let messageInfoString = String(data: messageInfoData, encoding: .utf8)
+        if let messageInfoData = try? JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted),
+           let messageInfoString = String(data: messageInfoData, encoding: .utf8) {
             metadata[ChannelMetadataKeys.chatContext] = messageInfoString
         }
 

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -368,11 +368,8 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         }
         
         do {
-            var languageDict : [String:String] = [:]
             let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
-            if let languageCodeString = languageCode.map(String.init) {
-                languageDict[ChannelMetadataKeys.kmUserLocale] = languageCodeString
-            }
+            let languageDict = [ChannelMetadataKeys.kmUserLocale : languageCode]
             let messageInfoData = try JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted)
             let messageInfoString = String(data: messageInfoData, encoding: .utf8) ?? ""
             metadata[ChannelMetadataKeys.chatContext] = messageInfoString

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -19,6 +19,7 @@ public enum ChannelMetadataKeys {
     static let teamId = "KM_TEAM_ID"
     static let conversationMetaData = "conversationMetadata" // dictionary mapped with this key will be shown on  ConversationInfo section
     static let groupCreationURL = "GROUP_CREATION_URL"
+    static let kmUserLocale = "kmUserLocale"
 }
 
 enum LocalizationKey {
@@ -365,6 +366,20 @@ public class KMConversationService: KMConservationServiceable, Localizable {
             let originName = "iOS: " + appID
             metadata.setValue(originName, forKey: ChannelMetadataKeys.groupCreationURL)
         }
+        
+        do {
+            var languageDict : [String:String] = [:]
+            let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
+            if let languageCodeString = languageCode.map(String.init) {
+                languageDict[ChannelMetadataKeys.kmUserLocale] = languageCodeString
+            }
+            let messageInfoData = try JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted)
+            let messageInfoString = String(data: messageInfoData, encoding: .utf8) ?? ""
+            metadata[ChannelMetadataKeys.chatContext] = messageInfoString
+        } catch {
+            print("error while setting group metadata : \(error.localizedDescription)")
+        }
+        
 
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,
               !messageMetadata.isEmpty


### PR DESCRIPTION
## Summary

Passed `kmUserLocale` inside groupMetadata  and messageMetadata which is used to display welcome message in a specific language

<img width="524" alt="image" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/d5364cad-f61b-41f4-9166-bcc358510f5a">

## Testing

1. Add welcome message in a specific language from [here](https://dashboard.kommunicate.io/settings/welcome-message).

2. Change your device language to the same language as that of welcome message.

3. Create a new conversation and verify that the welcome message is received for that specific language.

<img width="1440" alt="Screenshot 2023-08-25 at 6 33 36 PM" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/13a4b2bc-133d-4f51-b08d-86562bc735e1">

![image](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/93e745b6-95e5-48ca-8d5c-b15950be01c8)