### PR TITLE
[CM-1391] Added kmUserLocale in groupMetadata and messageMetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
+
+## Unreleased
+- Passed kmUserLocale in groupMetadata and messageMetaData
+
 ## [6.9.9] 2023-08-28
 - Fixed attachments upload issue
 

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -125,6 +125,16 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
         self.kmConversationViewConfiguration = kmConversationViewConfiguration
         tableView.isHidden = true
         super.init(configuration: configuration)
+        let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
+        if(languageCode?.description != ALUserDefaultsHandler.getDeviceDefaultLanguage()){
+            ALUserDefaultsHandler.setDeviceDefaultLanguage(languageCode?.description)
+        }
+        do{
+            try Kommunicate.defaultConfiguration.updateChatContext(with: [ChannelMetadataKeys.kmUserLocale : languageCode])
+            self.configuration.messageMetadata = Kommunicate.defaultConfiguration.messageMetadata
+        } catch {
+            print("Unable to update chat context")
+        }
         conversationListTableViewController.delegate = self
         localizedStringFileName = configuration.localizedStringFileName
     }

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -19,6 +19,7 @@ public enum ChannelMetadataKeys {
     static let teamId = "KM_TEAM_ID"
     static let conversationMetaData = "conversationMetadata" // dictionary mapped with this key will be shown on  ConversationInfo section
     static let groupCreationURL = "GROUP_CREATION_URL"
+    static let kmUserLocale = "kmUserLocale"
 }
 
 enum LocalizationKey {

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -81,6 +81,15 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         conversation: KMConversation,
         completion: @escaping (Response) -> Void
     ) {
+        let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
+        if(languageCode?.description != ALUserDefaultsHandler.getDeviceDefaultLanguage()){
+            ALUserDefaultsHandler.setDeviceDefaultLanguage(languageCode?.description)
+        }
+        do{
+            try Kommunicate.defaultConfiguration.updateChatContext(with: [ChannelMetadataKeys.kmUserLocale : languageCode])
+        } catch {
+            print("Unable to update chat context")
+        }
         let dispatchGroup = DispatchGroup()
 
         if let clientId = conversation.clientConversationId, !clientId.isEmpty {

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -114,6 +114,16 @@ open class KMConversationViewController: ALKConversationViewController {
     {
         kmConversationViewConfiguration = conversationViewConfiguration
         super.init(configuration: configuration, individualLaunch: individualLaunch)
+        let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
+        if(languageCode?.description != ALUserDefaultsHandler.getDeviceDefaultLanguage()){
+            ALUserDefaultsHandler.setDeviceDefaultLanguage(languageCode?.description)
+        }
+        do{
+            try Kommunicate.defaultConfiguration.updateChatContext(with: [ChannelMetadataKeys.kmUserLocale : languageCode])
+            self.configuration.messageMetadata = Kommunicate.defaultConfiguration.messageMetadata
+        } catch {
+            print("Unable to update chat context")
+        }
         addNotificationCenterObserver()
     }
 


### PR DESCRIPTION
## Summary

Passed `kmUserLocale` inside groupMetadata  and messageMetadata which is used to display welcome message in a specific language

<img width="524" alt="image" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/d5364cad-f61b-41f4-9166-bcc358510f5a">

## Testing

1. Add welcome message in a specific language from [here](https://dashboard.kommunicate.io/settings/welcome-message).

2. Change your device language to the same language as that of welcome message.

3. Create a new conversation and verify that the welcome message is received for that specific language.

<img width="1440" alt="Screenshot 2023-08-25 at 6 33 36 PM" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/13a4b2bc-133d-4f51-b08d-86562bc735e1">

![image](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/93e745b6-95e5-48ca-8d5c-b15950be01c8)