### PR TITLE
[CM-1629] Added support for XCode 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Added support for XCode 15 beta
+
 ## [7.0.0] 2023-09-07
 - Upgraded minimum SDK version to 13
 - Passed kmUserLocale in groupMetadata and messageMetaData

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -19,3 +19,20 @@ target 'Kommunicate_ExampleUITests' do
   inherit! :search_paths
   pod 'Kommunicate', :path => '../'
 end
+
+post_install do |installer|
+  installer.aggregate_targets.each do |target|
+    target.xcconfigs.each do |variant, xcconfig|
+      xcconfig_path = target.client_root + target.xcconfig_relative_path(variant)
+      IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
+    end
+  end
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      if config.base_configuration_reference.is_a? Xcodeproj::Project::Object::PBXFileReference
+        xcconfig_path = config.base_configuration_reference.real_path
+        IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
+      end
+    end
+  end
+end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -19,20 +19,3 @@ target 'Kommunicate_ExampleUITests' do
   inherit! :search_paths
   pod 'Kommunicate', :path => '../'
 end
-
-post_install do |installer|
-  installer.aggregate_targets.each do |target|
-    target.xcconfigs.each do |variant, xcconfig|
-      xcconfig_path = target.client_root + target.xcconfig_relative_path(variant)
-      IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
-    end
-  end
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      if config.base_configuration_reference.is_a? Xcodeproj::Project::Object::PBXFileReference
-        xcconfig_path = config.base_configuration_reference.real_path
-        IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
-      end
-    end
-  end
-end

--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -256,7 +256,7 @@ class ConversationVCNavBar: UIView, Localizable {
 
     func setupProfileNameAndImage(name: String, imageUrl: URL?, placeHolderImage: UIImage) {
         if let downloadURL = imageUrl {
-            let resource = ImageResource(downloadURL: downloadURL, cacheKey: downloadURL.absoluteString)
+            let resource = Kingfisher.ImageResource(downloadURL: downloadURL, cacheKey: downloadURL.absoluteString)
             profileImage.kf.setImage(with: resource, placeholder: placeHolderImage)
         } else {
             profileImage.image = placeHolderImage


### PR DESCRIPTION
## Summary

- DT_TOOLCHAIN_DIR was not able to evaluate LIBRARY_SEARCH_PATHS while building in XCode 15, hence updated the podfile to use TOOLCHAIN_DIR instead of DT_TOOLCHAIN_DIR. Check the issue [here.](https://github.com/CocoaPods/CocoaPods/issues/12012)
- ImageResource of KingFisher was conflicting with Xcode's GeneratedAssetSymbols.ImageResource, hence renamed the `ImageResource` as `Kingfisher.ImageResource`. Check the issue [here.](https://github.com/onevcat/Kingfisher/issues/2114)

## How testing was done ?

I tried to build with Xcode 14 as well as XCode 15 beta 8 and the app was building successfully