### PR TITLE
[CM-1635] Changed hidePostCTA flag in IOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 - Added custom input field rich message support in IOS SDK
 - Fixed Trial Period Alert closable issue.
 - Added support for XCode 15 beta
+- Fixed hidePostCTA not getting reflected in IOS SDK
 
 ## [7.0.0] 2023-09-07
 - Upgraded minimum SDK version to 13

--- a/Sources/Kommunicate/Classes/KMAppSettingsResponse.swift
+++ b/Sources/Kommunicate/Classes/KMAppSettingsResponse.swift
@@ -42,7 +42,7 @@ struct ChatWidgetResponse: Decodable {
     let showPoweredBy: Bool?
     let isSingleThreaded: Bool?
     let botMessageDelayInterval: Int?
-    let hidePostCTAEnabled: Bool?
+    let hidePostCTA: Bool?
     let preChatGreetingMsg: String?
     let zendeskChatSdkKey: String?
     let defaultUploadOverride : DefaultUploadOverride?

--- a/Sources/Kommunicate/Classes/KMAppSettingsService.swift
+++ b/Sources/Kommunicate/Classes/KMAppSettingsService.swift
@@ -68,7 +68,7 @@ class KMAppSettingService {
        }
        appSettings.buttonPrimaryColor = primaryColor
        appSettings.showPoweredBy = chatWidget.showPoweredBy ?? false
-       appSettings.hidePostCTAEnabled = chatWidget.hidePostCTAEnabled ?? false
+       appSettings.hidePostCTAEnabled = chatWidget.hidePostCTA ?? false
        appSettings.defaultUploadOverrideUrl = chatWidget.defaultUploadOverride?.url ?? ""
        appSettings.defaultUploadOverrideHeaders = chatWidget.defaultUploadOverride?.headers ?? [:]
        appSettingsUserDefaults.updateOrSetAppSettings(appSettings: appSettings)


### PR DESCRIPTION
## Summary
Changed hidePostCTA flag in iOS SDK.

## Testing
- Add suggested reply to your bot from [here.](https://dashboard.kommunicate.io/settings/chat-widget-configuration#hide-rich-button)
- Disable suggested replies showing on click from [here.](https://dashboard.kommunicate.io/settings/chat-widget-configuration#hide-rich-button)
- Check whether hidePostCTA is working or not.