### PR TITLE
Language metadata fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 - Added custom input field rich message support in IOS SDK
 - Fixed Trial Period Alert closable issue.
 - Added support for XCode 15 beta
+- Fixed language metadata clashing with message metaData
 
 ## [7.0.0] 2023-09-07
 - Upgraded minimum SDK version to 13


### PR DESCRIPTION
## Summary
In the group metadata language update we were earlier using KMConfiguration.updatechatcontext. When quick reply is sent and its metadata is set, it was clashing with the updated chat context. Hence, a new method is created now to set group meta which will not affect other functionalities.