### PR TITLE
[CM-1639] Added flag for identification of users with pseudo name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommun
 - Added custom input field rich message support in IOS SDK
 - Fixed Trial Period Alert closable issue.
 - Added support for XCode 15 beta
+- Added flag for identification of users with pseudo name
 
 ## [7.0.0] 2023-09-07
 - Upgraded minimum SDK version to 13

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -20,6 +20,8 @@ public enum ChannelMetadataKeys {
     static let conversationMetaData = "conversationMetadata" // dictionary mapped with this key will be shown on  ConversationInfo section
     static let groupCreationURL = "GROUP_CREATION_URL"
     static let kmUserLocale = "kmUserLocale"
+    static let kmPseudoUser = "KM_PSEUDO_USER"
+    static let pseudoName = "pseudoName"
 }
 
 enum LocalizationKey {


### PR DESCRIPTION
## Summary

Added `"KM_PSEUDO_USER": "{\n  \"hidden\" : true,\n  \"pseudoName\" : true\n}"` inside KmUser's metadata for identification of pseudoname during registration.

<img width="302" alt="Screenshot 2023-09-18 at 11 47 06 PM" src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139108613/b6c6263a-1fcf-4fea-9028-ebc5ed638f61">
