### PR TITLE
Fixed In dark mode rating icon names were not displaying.

### DIFF
--- a/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
+++ b/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
@@ -118,6 +118,7 @@ class EmojiRatingButton: UIView {
         let label = UILabel(frame: .zero)
         label.font = Style.Font.normal(size: 14).font()
         label.numberOfLines = 1
+        label.textColor = UIColor(netHex: 0x000000)
         label.backgroundColor = .clear
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Sources/Kommunicate/Classes/Views/RatingViewController.swift
@@ -34,6 +34,7 @@ class RatingViewController: UIViewController {
         let label = UILabel(frame: .zero)
         label.font = Style.Font.normal(size: 16).font()
         label.numberOfLines = 1
+        label.textColor = UIColor(netHex: 0x000000)
         label.backgroundColor = .clear
         label.text = LocalizedText.title
         label.textAlignment = .center


### PR DESCRIPTION
## Summary
- added colour to rating titles so that it will not change on dark mode.

## Change
- Before (Dark mode enabled)
<img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/1272d32d-ef15-4d56-bf70-2a2ab8f5ce59' width = 200 height = 400 />

- After (Dark mode enabled)
 <img src ='https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/085ee15a-bc47-46a2-9e4e-29895ee7de48' width = 200 height = 400 />

