### PR TITLE
[CM-1449] Dark Mode Support part -1 | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
-## Unreleased
-- Dark Mode Support Enabled.
-
 ## [7.0.1] 2023-09-26
 - Added Support For Auto Suggestions Rich Message
 - Added pseudonym support for iOS SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Dark Mode Support Enabled.
+
 ## [7.0.1] 2023-09-26
 - Added Support For Auto Suggestions Rich Message
 - Added pseudonym support for iOS SDK

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -823,10 +823,3 @@ extension KMConversationListViewController: UISearchBarDelegate {
         resultVC.clear()
     }
 }
-
-
-extension UIColor {
-    static func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
-        return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
-    }
-}

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -59,7 +59,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
 
     let backgroundView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
+        view.backgroundColor = .dynamicColor(light: .white, dark: .black)
         return view
     }()
 
@@ -83,7 +83,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
     lazy var noConversationLabel: UILabel = {
         let label = UILabel()
         label.text = localizedString(forKey: "NoConversationsLabelText", fileName: configuration.localizedStringFileName)
-        label.textColor = UIColor.black
+        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
         label.textAlignment = .center
         label.numberOfLines = 3
         label.font = Font.normal(size: 18).font()
@@ -821,5 +821,12 @@ extension KMConversationListViewController: UISearchBarDelegate {
     public func searchBarCancelButtonClicked(_: UISearchBar) {
         showNavigationItems()
         resultVC.clear()
+    }
+}
+
+
+extension UIColor {
+    static func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
+        return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
     }
 }

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -127,7 +127,7 @@ open class KMConversationViewController: ALKConversationViewController {
         customNavigationView.setupAppearance()
         if #available(iOS 13.0, *) {
             // Always adopt a light interface style.
-            overrideUserInterfaceStyle = .light
+//            overrideUserInterfaceStyle = .light
         }
 
         checkPlanAndShowSuspensionScreen()

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -125,10 +125,6 @@ open class KMConversationViewController: ALKConversationViewController {
     override open func viewDidLoad() {
         super.viewDidLoad()
         customNavigationView.setupAppearance()
-        if #available(iOS 13.0, *) {
-            // Always adopt a light interface style.
-//            overrideUserInterfaceStyle = .light
-        }
 
         checkPlanAndShowSuspensionScreen()
         addViewConstraints()

--- a/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
+++ b/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
@@ -33,7 +33,7 @@ class AwayMessageView: UIView {
         label.font = UIFont(name: "HelveticaNeue-Light", size: 14)
         label.contentMode = .center
         label.textAlignment = .center
-        label.textColor = UIColor(netHex: 0x676262)
+        label.textColor = .dynamicColor(light: UIColor(netHex: 0x676262), dark: .lightGray)
         label.numberOfLines = 4
         return label
     }()

--- a/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
+++ b/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
@@ -118,7 +118,7 @@ class EmojiRatingButton: UIView {
         let label = UILabel(frame: .zero)
         label.font = Style.Font.normal(size: 14).font()
         label.numberOfLines = 1
-        label.textColor = UIColor(netHex: 0x000000)
+        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
         label.backgroundColor = .clear
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Sources/Kommunicate/Classes/Views/RatingViewController.swift
@@ -175,7 +175,7 @@ class RatingViewController: UIViewController {
     func setupView() {
         transitioningDelegate = bottomSheetTransitionDelegate
         modalPresentationStyle = .custom
-        view.backgroundColor = .dynamicColor(light: .white, dark: UIColor(netHex: 0x313131))
+        view.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         view.layer.cornerRadius = 8
         commentsView.isHidden = true
         submitButton.isHidden = true

--- a/Sources/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Sources/Kommunicate/Classes/Views/RatingViewController.swift
@@ -34,7 +34,7 @@ class RatingViewController: UIViewController {
         let label = UILabel(frame: .zero)
         label.font = Style.Font.normal(size: 16).font()
         label.numberOfLines = 1
-        label.textColor = UIColor(netHex: 0x000000)
+        label.textColor = .dynamicColor(light: .black, dark: .white)
         label.backgroundColor = .clear
         label.text = LocalizedText.title
         label.textAlignment = .center
@@ -73,7 +73,7 @@ class RatingViewController: UIViewController {
         textView.layer.borderWidth = 0.7
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.backgroundColor = .clear
-        textView.textColor = .black
+        textView.textColor = .dynamicColor(light: .black, dark: .white)
         return textView
     }()
 
@@ -175,7 +175,7 @@ class RatingViewController: UIViewController {
     func setupView() {
         transitioningDelegate = bottomSheetTransitionDelegate
         modalPresentationStyle = .custom
-        view.backgroundColor = .white
+        view.backgroundColor = .dynamicColor(light: .white, dark: UIColor(netHex: 0x313131))
         view.layer.cornerRadius = 8
         commentsView.isHidden = true
         submitButton.isHidden = true


### PR DESCRIPTION
## Summary
- Added dark mode support in noConversation Screen.
- Dynamic text color Support to away message text.
- Dynamic Support for rating view controller. (titleText, iconTitle, typingText)
- Disabled the forced  overrideUserInterfaceStyle to light.

## Note
- User need to enable dark mode from defaultConfiguration.isDarkModeEnabled. By default it is false.

## Reference
- Figma link : https://www.figma.com/file/4cSLo3RwfBgZCZCeTtKzgP/iOS-UI%2FUX?type=design&node-id=0%3A1&mode=design&t=SIX3kccGAY0KhEtJ-1

## Video Preview

https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/9b93fdce-582b-4f2d-b5bb-a65e546e417f

