### PR TITLE
[CM-1459] Dark Mode Support Part -2 

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -59,7 +59,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
 
     let backgroundView: UIView = {
         let view = UIView()
-        view.backgroundColor = .dynamicColor(light: .white, dark: .black)
+        view.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.backgroundDarkColor())
         return view
     }()
 
@@ -73,9 +73,13 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
     lazy var startNewConversationBottomButton: UIButton = {
         let button = UIButton(type: .custom)
         button.addTarget(self, action: #selector(compose), for: .touchUpInside)
-        button.backgroundColor = kmConversationViewConfiguration.startNewConversationButtonBackgroundColor == nil ? ALKAppSettingsUserDefaults().getAppBarTintColor() : kmConversationViewConfiguration.startNewConversationButtonBackgroundColor
+        let lightColor = kmConversationViewConfiguration.startNewConversationButtonBackgroundColor ?? ALKAppSettingsUserDefaults().getAppBarTintColor()
+        let darkColor = kmConversationViewConfiguration.startNewConversationButtonDarkBackgroundColor ?? ALKAppSettingsUserDefaults().getAppBarTintColor()
+        let backgroundColor = UIColor.kmDynamicColor(light: lightColor, dark: darkColor)
+        button.backgroundColor = backgroundColor
         button.setTitle(LocalizedText.startNewConversationTitle, for: .normal)
-        button.setTitleColor(kmConversationViewConfiguration.startNewConversationButtonTextColor, for: .normal)
+        let darkTitleColor = kmConversationViewConfiguration.startNewConversationButtonDarkTextColor ?? kmConversationViewConfiguration.startNewConversationButtonTextColor
+        button.setTitleColor(UIColor.kmDynamicColor(light: kmConversationViewConfiguration.startNewConversationButtonTextColor, dark: darkTitleColor), for: .normal)
         button.isUserInteractionEnabled = true
         return button
     }()
@@ -83,7 +87,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
     lazy var noConversationLabel: UILabel = {
         let label = UILabel()
         label.text = localizedString(forKey: "NoConversationsLabelText", fileName: configuration.localizedStringFileName)
-        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
+        label.textColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         label.textAlignment = .center
         label.numberOfLines = 3
         label.font = Font.normal(size: 18).font()

--- a/Sources/Kommunicate/Classes/KMConversationViewConfiguration.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewConfiguration.swift
@@ -22,10 +22,19 @@ public struct KMConversationViewConfiguration {
     public var toolbarSubtitleRating: Float = -1.0
     /// Customize Text color of FAQ button on conversation, conversation list screen
     public var faqTextColor : UIColor = UIColor.white
+    /// Customize Text dark color of FAQ button on conversation, conversation list screen
+    public var faqTextDarkColor : UIColor = UIColor.white
     /// Customize background color of FAQ button on conversation, conversation list screen
     public var faqBackgroundColor : UIColor = UIColor(hexString: "ffffff", alpha: 0.24)
-    /// Customize the Start New Conversation Button (Background Color, TextColor ) on Conversation List Screen
+    /// Customize dark background color of FAQ button on conversation, conversation list screen
+    public var faqDarkBackgroundColor : UIColor = UIColor(hexString: "ffffff", alpha: 0.24)
+    /// Customize the Start New Conversation Button Background Color on Conversation List Screen
     public var startNewConversationButtonBackgroundColor: UIColor? = nil
+    /// Customize the Start New Conversation Button TextColor on Conversation List Screen
     public var startNewConversationButtonTextColor: UIColor = UIColor.white
+    /// Customize the Start New Conversation Button Background Dark Color on Conversation List Screen
+    public var startNewConversationButtonDarkBackgroundColor: UIColor? = nil
+    /// Customize the Start New Conversation Button TextDarkColor on Conversation List Screen
+    public var startNewConversationButtonDarkTextColor: UIColor? = nil
     public init() {}
 }

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -67,8 +67,8 @@ open class Kommunicate: NSObject, Localizable {
         config.isProfileTapActionEnabled = false
         var navigationItemsForConversationList = [ALKNavigationItem]()
         var faqItem = ALKNavigationItem(identifier: faqIdentifier, text: NSLocalizedString("FaqTitle", value: "FAQ", comment: ""))
-        faqItem.faqTextColor = kmConversationViewConfiguration.faqTextColor
-        faqItem.faqBackgroundColor = kmConversationViewConfiguration.faqBackgroundColor
+        faqItem.faqTextColor = .kmDynamicColor(light: kmConversationViewConfiguration.faqTextColor, dark: kmConversationViewConfiguration.faqTextDarkColor)
+        faqItem.faqBackgroundColor = .kmDynamicColor(light: kmConversationViewConfiguration.faqBackgroundColor, dark: kmConversationViewConfiguration.faqDarkBackgroundColor)
         navigationItemsForConversationList.append(faqItem)
         var navigationItemsForConversationView = [ALKNavigationItem]()
         navigationItemsForConversationView.append(faqItem)

--- a/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
+++ b/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
@@ -33,7 +33,7 @@ class AwayMessageView: UIView {
         label.font = UIFont(name: "HelveticaNeue-Light", size: 14)
         label.contentMode = .center
         label.textAlignment = .center
-        label.textColor = .dynamicColor(light: UIColor(netHex: 0x676262), dark: .lightGray)
+        label.textColor = .kmDynamicColor(light: UIColor(netHex: 0x676262), dark: .lightGray)
         label.numberOfLines = 4
         return label
     }()

--- a/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
+++ b/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
@@ -118,7 +118,7 @@ class EmojiRatingButton: UIView {
         let label = UILabel(frame: .zero)
         label.font = Style.Font.normal(size: 14).font()
         label.numberOfLines = 1
-        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
+        label.textColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         label.backgroundColor = .clear
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Kommunicate/Classes/Views/RatingViewController.swift
+++ b/Sources/Kommunicate/Classes/Views/RatingViewController.swift
@@ -34,7 +34,7 @@ class RatingViewController: UIViewController {
         let label = UILabel(frame: .zero)
         label.font = Style.Font.normal(size: 16).font()
         label.numberOfLines = 1
-        label.textColor = .dynamicColor(light: .black, dark: .white)
+        label.textColor = .kmDynamicColor(light: .black, dark: .white)
         label.backgroundColor = .clear
         label.text = LocalizedText.title
         label.textAlignment = .center
@@ -73,7 +73,7 @@ class RatingViewController: UIViewController {
         textView.layer.borderWidth = 0.7
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.backgroundColor = .clear
-        textView.textColor = .dynamicColor(light: .black, dark: .white)
+        textView.textColor = .kmDynamicColor(light: .black, dark: .white)
         return textView
     }()
 
@@ -175,7 +175,7 @@ class RatingViewController: UIViewController {
     func setupView() {
         transitioningDelegate = bottomSheetTransitionDelegate
         modalPresentationStyle = .custom
-        view.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        view.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         view.layer.cornerRadius = 8
         commentsView.isHidden = true
         submitButton.isHidden = true


### PR DESCRIPTION
## Summary
- Added Customisation for dark color for  Conversation Background Color. `Kommunicate.defaultConfiguration.backgroundDarkColor`
- Added Customisation  for dark color for Conversation Screen Bottom Attachment bar Color. `Kommunicate.defaultConfiguration.chatBarAttachmentViewBackgroundColor`
- Added Customisation  for dark color Conversation Info Model added parameters with default values. `KMConversationInfoViewModel(infoContent: "This is your conversation info text", leadingImage: leading, trailingImage:trailing, backgroundColor: bg, contentColor: UIColor.white, contentFont:font,darkBackgroundColor: .white, contentDarkColor: .black)`
- Added Customisation for dark Color for FAQ Customisation. `Kommunicate.kmConversationViewConfiguration.faqDarkBackgroundColor` , `Kommunicate.kmConversationViewConfiguration.faqTextDarkColor`
- Added Customisation for dark color for Start new Conversation bottom Button. `Kommunicate.kmConversationViewConfiguration.startNewConversationButtonDarkBackgroundColor`, `Kommunicate.kmConversationViewConfiguration.startNewConversationButtonDarkTextColor`
- Added dynamic color change support in "Speech to text Section".