### PR TITLE
[CM-1759] Quick Reply implementation for TaxBuddy

### DIFF
--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -1150,7 +1150,7 @@ open class Kommunicate: NSObject, Localizable {
         ALApplozicSettings.setFilterContactsStatus(true)
         ALUserDefaultsHandler.setDebugLogsRequire(true)
         ALApplozicSettings.setSwiftFramework(true)
-        let hiddenMessageMetaDataFlagArray = ["KM_ASSIGN", "KM_STATUS" , "KM_ASSIGN_TO", "KM_ASSIGN_TEAM"]
+        let hiddenMessageMetaDataFlagArray = ["KM_ASSIGN", "KM_STATUS" , "KM_ASSIGN_TO", "KM_ASSIGN_TEAM", "KM_EVENT"]
         ALApplozicSettings.hideMessages(withMetadataKeys:hiddenMessageMetaDataFlagArray)
         ALApplozicSettings.enableS3StorageService(true)
     }


### PR DESCRIPTION
### Overview
Taxbuddy wanted to reassign a conversation back to a bot by using quick replies provided in the dashboard.
We have modified the quickreplies for the same. 
The idea is that they will identify the event at universal webhook and trigger reassignment.

### Code changes 

- Added a "KM_EVENT" key in the list of hidden metadata keys to hide the quick reply message for the user

### What do you want to achieve?
- Provide a way to send specific events along with the quickreplies.

### Verified
- [x] SPM

### Video

https://github.com/Kommunicate-io/Kommunicate-iOS-AgentApp/assets/139108613/34869634-833c-445a-93ae-3eb82f819844