### PR TITLE
[CM-1713] Zendesk (Zopim) integration optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Zendesk (Zopim) integration optimisations
+
 ## [7.1.0] 2023-12-23
 - Added support to trigger intents through quick reply
 - Restrict agent reply for zendesk conversation

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -626,11 +626,9 @@ open class Kommunicate: NSObject, Localizable {
         // If bot is handling the chat then we shouldn't send any messages to Zendesk.
         if let assignee = channel.assigneeUserId, !assignee.isEmpty,
            let contact = ALContactService().loadContact(byKey: "userId", value: assignee) {
-            if contact.roleType == NSNumber.init(value: AL_BOT.rawValue) {
-              zendeskHandler.updateHandoffFlag(false)
-          } else {
-              zendeskHandler.updateHandoffFlag(true)
-          }
+            if contact.roleType == NSNumber.init(value: AL_APPLICATION_WEB_ADMIN.rawValue) {
+                zendeskHandler.handedOffToAgent(groupId: existingZendeskConversationId.stringValue, happendNow: false)
+            }
         }
         
         zendeskHandler.initiateZendesk(key: accountKey)


### PR DESCRIPTION
## Summary

- Fixed sync call happening even when new message created at time == last sync time
- For the first time while opening zendesk it was not working because there was no handoff to agent as soon as the conversation is released from the bot
- Fixed chat transcript sending multiple times for zendesk handoff