### PR TITLE
Removed unnecessay group metadata api on createconversation flow

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -107,15 +107,6 @@ public class KMConversationService: KMConservationServiceable, Localizable {
                             }
                         }
                     }
-                    dispatchGroup.enter()
-                    if self.groupMetadata.count < 0 {
-                        dispatchGroup.leave()
-                    } else {
-                        self.updateGroupMetadata(groupId: NSNumber(value: groupID), channelKey: clientId, metadata: self.groupMetadata) { result in
-                            response = result
-                            dispatchGroup.leave()
-                        }
-                    }
                     dispatchGroup.notify(queue: .main) {
                         completion(response)
                     }

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -84,8 +84,6 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         conversation: KMConversation,
         completion: @escaping (Response) -> Void
     ) {
-        let dispatchGroup = DispatchGroup()
-
         if let clientId = conversation.clientConversationId, !clientId.isEmpty {
             isGroupPresent(clientId: clientId, completion: { present, channel in
                 if present {
@@ -94,21 +92,18 @@ public class KMConversationService: KMConservationServiceable, Localizable {
 
                     if let currentAssignee = self.assigneeUserIdFor(groupId: groupID), let newAssignee = conversation.conversationAssignee {
                         if !(newAssignee.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty), newAssignee != currentAssignee {
-                            dispatchGroup.enter()
+                           
                             self.assignConversation(groupId: groupID, to: newAssignee) { result in
                                 switch result {
                                 case .success:
-                                    dispatchGroup.leave()
+                                    completion(response)
                                 case let .failure(error):
                                     response.error = error
                                     response.success = false
-                                    dispatchGroup.leave()
+                                    completion(response)
                                 }
                             }
                         }
-                    }
-                    dispatchGroup.notify(queue: .main) {
-                        completion(response)
                     }
                 } else {
                     self.createNewChannelAndConversation(conversation: conversation, completion: { response in

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -104,6 +104,8 @@ public class KMConversationService: KMConservationServiceable, Localizable {
                                 }
                             }
                         }
+                    } else {
+                        completion(response)
                     }
                 } else {
                     self.createNewChannelAndConversation(conversation: conversation, completion: { response in


### PR DESCRIPTION
## Summary
- Whenever `createAndShowConversation` function called, update group metadata api is getting called
- So in backend it is stored as a message(message metadata update by user) and hence last message of the group is getting differed.


