### PR TITLE
[CM-1941] Added support for button trigger in reply metadata

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -157,7 +157,10 @@ open class KMConversationViewController: ALKConversationViewController {
         guard !viewModel.messageModels.isEmpty else { return }
         if let lastMessage = viewModel.messageModels.last, !lastMessage.isMyMessage {
             isAwayMessageViewHidden = true
+            print(lastMessage.metadata)
         }
+        
+       
     }
     
     
@@ -199,6 +202,17 @@ open class KMConversationViewController: ALKConversationViewController {
            count = messageArray.count
            self.viewModel.addMessagesToList(messageList)
        }
+    }
+    
+    func hideChatbar(){
+        if let message = self.viewModel.lastMessage,
+           let metadata = message.metadata as? [String:Any],
+           let hidechatbar = metadata["hideChatbar"] as? Bool,
+            hidechatbar {
+            isChatBarHidden = true
+        } else {
+            isChatBarHidden = false
+        }
     }
 
     // This method is used to delay the bot message as well as to show typing indicator
@@ -582,29 +596,46 @@ open class KMConversationViewController: ALKConversationViewController {
                                       languageCode language: String?)
     {
         do {
-            let customMetadata = metadata ?? [String: Any]()
+            var replyMetadata = metadata ?? [String: Any]() // reply meta data
 
             if let updatedLanguage = language {
                 try configuration.updateUserLanguage(tag: updatedLanguage)
             }
-
+            
+            
+            guard !replyMetadata.isEmpty else {
+                viewModel.send(message: text, metadata: configuration.messageMetadata as? [String: Any])
+                return
+            }
+            
             guard let messageMetadata = configuration.messageMetadata as? [String: Any],
-                  let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,!jsonData.isEmpty,
-                  let data = jsonData.data(using: .utf8),
-                  let chatContextData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any]
+                  !messageMetadata.isEmpty else {
+                viewModel.send(message:text, metadata: replyMetadata)
+                return
+            }
+            
+            guard var replyChatContextData = replyMetadata[ChannelMetadataKeys.chatContext] as? [String:Any] else {
+                replyMetadata.merge(messageMetadata) { $1 }
+                viewModel.send(message: text, metadata: replyMetadata)
+                return
+            }
+            
+           
+            guard let jsonData = messageMetadata[ChannelMetadataKeys.chatContext] as? String,
+               !jsonData.isEmpty,
+               let data = jsonData.data(using: .utf8),
+               let messageChatContextData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: Any],
+                !messageChatContextData.isEmpty
             else {
-                viewModel.send(message: text, metadata: customMetadata)
+                viewModel.send(message: text, metadata: replyMetadata)
                 return
             }
-
-            if customMetadata.isEmpty {
-                viewModel.send(message: text, metadata: messageMetadata)
-                return
-            }
-            var replyMetaData = customMetadata[ChannelMetadataKeys.chatContext] as? [String: Any]
-            replyMetaData?.merge(chatContextData) { $1 }
-            let metaDataToSend = [ChannelMetadataKeys.chatContext: replyMetaData]
-            viewModel.send(message: text, metadata: metaDataToSend as [AnyHashable: Any])
+          
+            replyChatContextData.merge(messageChatContextData) {$1}
+            var chatContextDataTobeSent = [ChannelMetadataKeys.chatContext:replyChatContextData]
+            replyMetadata.merge(chatContextDataTobeSent, uniquingKeysWith: {$1})
+            
+            viewModel.send(message: text, metadata: replyMetadata)
         } catch {
             print("Error while sending quick reply message %@", error.localizedDescription)
         }

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -157,10 +157,7 @@ open class KMConversationViewController: ALKConversationViewController {
         guard !viewModel.messageModels.isEmpty else { return }
         if let lastMessage = viewModel.messageModels.last, !lastMessage.isMyMessage {
             isAwayMessageViewHidden = true
-            print(lastMessage.metadata)
         }
-        
-       
     }
     
     
@@ -204,17 +201,6 @@ open class KMConversationViewController: ALKConversationViewController {
        }
     }
     
-    func hideChatbar(){
-        if let message = self.viewModel.lastMessage,
-           let metadata = message.metadata as? [String:Any],
-           let hidechatbar = metadata["hideChatbar"] as? Bool,
-            hidechatbar {
-            isChatBarHidden = true
-        } else {
-            isChatBarHidden = false
-        }
-    }
-
     // This method is used to delay the bot message as well as to show typing indicator
     func showDelayAndTypingIndicatorForMessage() {
         if count >= messageArray.count {


### PR DESCRIPTION
## Summary
- Fixed  When button is linked with intent via button trigger from dashboard, local message metadata is not reaching the webhook
- When reply meta data  added along with button trigger, reply meta data is not reaching the webhook