### PR TITLE
[CM-1964] Fixed assignee image is not getting rendered on conversation when it is created with title

### DIFF
--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -241,7 +241,7 @@ class ConversationVCNavBar: UIView, Localizable {
     private func setupProfile(_ contact: ALContact?, _ channel: ALChannel) {
         var url: URL?
 
-        if let imageUrl = channel.channelImageURL {
+        if let imageUrl = contact?.contactImageUrl {
             url = URL(string: imageUrl)
         }
         if channel.type == Int16(SUPPORT_GROUP.rawValue) {


### PR DESCRIPTION
## Summary
 - Fixed assignee image is not getting rendered on conversation when it is created with title.
 - Instad placeholder image is getting rendered


## Issue
<img src ="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/121929127/9b067130-659b-46d2-8374-caa152b68a38" width = 200 height=400 />


## After fix
<img src="https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/121929127/5349367a-b6da-4e3d-8864-c3339f46f967" width = 200 height=400 />
