### PR TITLE
Fix for conversation not opening second time with same assignee

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -103,6 +103,8 @@ public class KMConversationService: KMConservationServiceable, Localizable {
                                     completion(response)
                                 }
                             }
+                        } else {
+                            completion(response)
                         }
                     } else {
                         completion(response)


### PR DESCRIPTION
## Summary
- Added the else block to share the response when there is no change in the assignee.