### PR TITLE
[CM-1234] Fixed name getting cut issue 

### DIFF
--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -109,8 +109,8 @@ class ConversationVCNavBar: UIView, Localizable {
         let stackView = UIStackView(arrangedSubviews: [self.profileName])
         stackView.alignment = .fill
         stackView.axis = .vertical
-        stackView.distribution = .fillEqually
-        stackView.spacing = 2
+        stackView.distribution = .fill
+        stackView.spacing = 0.5
         return stackView
     }()
 
@@ -172,24 +172,28 @@ class ConversationVCNavBar: UIView, Localizable {
         }
         var subtitleText: String = ""
         var showCustomSubtitle: Bool = false
-        if let toolbarSubtitle = configuration.toolbarSubtitleText as? String, !toolbarSubtitle.isEmpty {
+        
+        if  !configuration.toolbarSubtitleText.isEmpty {
             customSubtitleView.addArrangedSubview(customSubtitleText)
-            subtitleText = toolbarSubtitle
+            subtitleText = configuration.toolbarSubtitleText
             showCustomSubtitle = true
         }
-        if let toolbarRating = configuration.toolbarSubtitleRating as? Float, !toolbarRating.isEqual(to: -1.0) {
+        
+        if !configuration.toolbarSubtitleRating.isEqual(to: -1.0) {
             subtitleText.append(subtitleText.isEmpty ? "" : " | ")
             customSubtitleView.addArrangedSubview(ratingIcon)
             customSubtitleView.addArrangedSubview(customRating)
-            customRating.text = toolbarRating.description
+            customRating.text = configuration.toolbarSubtitleRating.description
             showCustomSubtitle = true
         }
+        
         if(showCustomSubtitle) {
             customSubtitleText.text = subtitleText
             profileView.addArrangedSubview(self.customSubtitleView)
         } else {
             profileView.addArrangedSubview(self.onlineStatusText)
         }
+        
         statusIconBackgroundColor.backgroundColor = navigationBarProxy.barTintColor
     }
 
@@ -206,7 +210,7 @@ class ConversationVCNavBar: UIView, Localizable {
         profileImage.topAnchor.constraint(equalTo: topAnchor, constant: 5).isActive = true
         profileImage.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5).isActive = true
         profileImage.widthAnchor.constraint(equalToConstant: 37).isActive = true
-        profileName.heightAnchor.constraint(equalToConstant: 37).isActive = true
+        profileImage.heightAnchor.constraint(equalToConstant: 37).isActive = true
 
         statusIconBackgroundColor.bottomAnchor.constraint(equalTo: profileImage.bottomAnchor, constant: 0).isActive = true
         statusIconBackgroundColor.leadingAnchor.constraint(equalTo: profileImage.trailingAnchor, constant: -10).isActive = true

--- a/Sources/Kommunicate/Classes/KMConversationViewConfiguration.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewConfiguration.swift
@@ -18,7 +18,7 @@ public struct KMConversationViewConfiguration {
     public var startNewButtonIcon: UIImage? = UIImage(named: "icon_new_chat_red", in: Bundle.kommunicate, compatibleWith: nil)
     /// If enabled, the user can't send a message when a conversation is assigned to a bot.
     public var restrictMessageTypingWithBots = false
-    public var toolbarSubtitleText = ""
+    public var toolbarSubtitleText: String = ""
     public var toolbarSubtitleRating: Float = -1.0
     /// Customize Text color of FAQ button on conversation, conversation list screen
     public var faqTextColor : UIColor = UIColor.white


### PR DESCRIPTION
## Summary
- Fixed assignee name getting cut in ui issue
- Optimised the code on ConversationVCNavBar file

## Before
(letters of the name is getting cut the bottom)

<img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/121929127/1ace6307-8950-45d3-b73f-8fdd7c40e036' width = 200 height = 400/>

## After

<img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/121929127/69f0687f-22bc-4c86-a509-81b5ff046e96' width = 200 height = 400/>
