### PR TITLE
[CM-1827] In App Notification Banner Colour Customization 

### DIFF
--- a/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
+++ b/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
@@ -45,7 +45,7 @@ public class KMPushNotificationHandler: Localizable {
                 case NSNumber(value: APP_STATE_ACTIVE.rawValue):
                     guard !pushNotificationHelper.isNotificationForActiveThread(notificationData) else { return }
 
-                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId, completionHandler: {
+                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId,titleTest: configuration.inAppBannerTextColor, contentTextColor: configuration.inAppBannerContentColor, backgroundColor: configuration.inAppBannerColor, completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)
                     })

--- a/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
+++ b/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
@@ -45,7 +45,7 @@ public class KMPushNotificationHandler: Localizable {
                 case NSNumber(value: APP_STATE_ACTIVE.rawValue):
                     guard !pushNotificationHelper.isNotificationForActiveThread(notificationData) else { return }
 
-                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId,titleTest: configuration.inAppBannerTextColor, contentTextColor: configuration.inAppBannerContentColor, backgroundColor: configuration.inAppBannerColor, backgroundShadowColor: configuration.inAppBannerShadowColor,shadowRadius: configuration.inAppBannerShadowRadius, cornerRadius: configuration.inAppBannerRadius, shadowOpacity: configuration.inAppBannerOpacity, completionHandler: {
+                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId,titleTest: configuration.inAppBannerTextColor, contentTextColor: configuration.inAppBannerContentColor, backgroundColor: configuration.inAppBannerColor, backgroundShadowColor: configuration.inAppBannerShadowColor,shadowRadius: configuration.inAppBannerShadowRadius, cornerRadius: configuration.inAppBannerRadius, shadowOpacity: configuration.inAppBannerShadowOpacity, completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)
                     })

--- a/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
+++ b/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
@@ -45,7 +45,7 @@ public class KMPushNotificationHandler: Localizable {
                 case NSNumber(value: APP_STATE_ACTIVE.rawValue):
                     guard !pushNotificationHelper.isNotificationForActiveThread(notificationData) else { return }
 
-                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId,titleTest: configuration.inAppBannerTextColor, contentTextColor: configuration.inAppBannerContentColor, backgroundColor: configuration.inAppBannerColor, completionHandler: {
+                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId,titleTest: configuration.inAppBannerTextColor, contentTextColor: configuration.inAppBannerContentColor, backgroundColor: configuration.inAppBannerColor, backgroundShadowColor: configuration.inAppBannerShadowColor,shadowRadius: configuration.inAppBannerShadowRadius, cornerRadius: configuration.inAppBannerRadius, shadowOpacity: configuration.inAppBannerOpacity, completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)
                     })


### PR DESCRIPTION
## Summary
- Added Customisation to update color of in App Banner. Customisation is accessible for Background Color, Title Color, Content Color.

## Code
```
            Kommunicate.defaultConfiguration.inAppBannerColor = UIColor.kmDynamicColor(light: .systemBrown, dark: .systemBlue)
            Kommunicate.defaultConfiguration.inAppBannerTextColor = UIColor.kmDynamicColor(light: .white, dark: .black)
            Kommunicate.defaultConfiguration.inAppBannerContentColor = UIColor.kmDynamicColor(light: .white, dark: .black)
            Kommunicate.defaultConfiguration.inAppBannerRadius = 12
            Kommunicate.defaultConfiguration.inAppBannerShadowRadius = 15
            Kommunicate.defaultConfiguration.inAppBannerShadowOpacity = 0.5
            Kommunicate.defaultConfiguration.inAppBannerShadowColor = UIColor.kmDynamicColor(light: .black, dark: .red)
```

## Images (Before and After Customisation)

<img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/e80bfbc4-8b8f-4907-ad61-6553fee148fb' height = 400/> <img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/e84f4402-2b20-47db-a079-20d5773e3a7d' height = 400/>

## Video

https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/assets/139110221/ff0251e1-f055-460c-bba7-aec257953dd4

