### PR TITLE
Revert "[CM-1827] In App Notification Banner Colour Customization "

### DIFF
--- a/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
+++ b/Sources/Kommunicate/Classes/KMPushNotificationHandler.swift
@@ -45,7 +45,7 @@ public class KMPushNotificationHandler: Localizable {
                 case NSNumber(value: APP_STATE_ACTIVE.rawValue):
                     guard !pushNotificationHelper.isNotificationForActiveThread(notificationData) else { return }
 
-                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId,titleTest: configuration.inAppBannerTextColor, contentTextColor: configuration.inAppBannerContentColor, backgroundColor: configuration.inAppBannerColor, backgroundShadowColor: configuration.inAppBannerShadowColor,shadowRadius: configuration.inAppBannerShadowRadius, cornerRadius: configuration.inAppBannerRadius, shadowOpacity: configuration.inAppBannerShadowOpacity, completionHandler: {
+                    ALUtilityClass.thirdDisplayNotificationTS(message, andForContactId: nil, withGroupId: notificationData.groupId, completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)
                     })


### PR DESCRIPTION
Reverts Kommunicate-io/Kommunicate-iOS-SDK#427

Reverted due to gesture recogniser not working.