### PR TITLE
[CM-1844] rateConversationMenuOption should be not come when CSAT is Disabled | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -223,6 +223,9 @@ open class Kommunicate: NSObject, Localizable {
                     kmAppSetting.updateAppsettings(chatWidgetResponse: appSetting.chatWidget)
                     KMAppUserDefaultHandler.shared.isCSATEnabled
                         = appSetting.collectFeedback ?? false
+                    if !KMAppUserDefaultHandler.shared.isCSATEnabled {
+                        Kommunicate.defaultConfiguration.rateConversationMenuOption = false
+                    }
                     if let zendeskaccountKey = appSetting.chatWidget?.zendeskChatSdkKey {
                         ALApplozicSettings.setZendeskSdkAccountKey(zendeskaccountKey)
                     }


### PR DESCRIPTION
## Summary
- Added a check for the isCSATEnabled for rateConversationMenuOption at time of register.

## Image (Before - After)

- In this the configuration for showing rateConversationMenuOption is true from code and from Dashboard the rating is disabled.

<img src = 'https://github.com/user-attachments/assets/4ed49f4b-fd30-42a0-8c5e-6dab60299e4b' width = 300/> <img src = 'https://github.com/user-attachments/assets/038e0851-e2b3-4935-958d-03bf6de8fa25' width = 300/>



