### PR TITLE
[CM-1393] Rating asked everytime opening a resolved conversation | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -692,6 +692,10 @@ extension KMConversationViewController: NavigationBarCallbacks {
 
 extension KMConversationViewController {
     func checkFeedbackAndShowRatingView() {
+        let isConversationRecentlyRated: Bool = {
+            guard let lastMessage = viewModel.messageModels.last else { return false }
+            return lastMessage.messageType == .information && lastMessage.message == "rated the conversation"
+        }()
         guard isClosedConversation else {
             isClosedConversationViewHidden = true
             hideRatingView()
@@ -710,7 +714,7 @@ extension KMConversationViewController {
                     self?.showRatingView()
                     return
                 }
-                guard !Kommunicate.defaultConfiguration.oneTimeRating else{
+                guard !Kommunicate.defaultConfiguration.oneTimeRating && !isConversationRecentlyRated else{
                     return
                 }
                 self?.showRatingView()

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -693,8 +693,8 @@ extension KMConversationViewController: NavigationBarCallbacks {
 extension KMConversationViewController {
     func checkFeedbackAndShowRatingView() {
         let isConversationRecentlyRated: Bool = {
-            guard let lastMessage = viewModel.messageModels.last else { return false }
-            return lastMessage.messageType == .information && lastMessage.message == "rated the conversation"
+            guard let lastMessage = viewModel.messageModels.last, let metadata = lastMessage.metadata else { return false }
+            return lastMessage.messageType == .information && metadata["feedback"] != nil
         }()
         guard isClosedConversation else {
             isClosedConversationViewHidden = true


### PR DESCRIPTION
## Summary
- Added a check of last message if the last message is rating message then it will not ask for rating on every opening of the conversation.

## Video (Before)

https://github.com/user-attachments/assets/ca63669c-070b-4fda-ac18-1589a73d6ab6


## Video (After)


https://github.com/user-attachments/assets/e4ec0aee-9133-4f14-a86e-4fe0251db0e2



