### PR TITLE
Fix for SPM and Update User Language | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/Extensions/KMConfiguration+Extension.swift
+++ b/Sources/Kommunicate/Classes/Extensions/KMConfiguration+Extension.swift
@@ -121,7 +121,7 @@ public extension ALKConfiguration {
     /// - Parameter tag: Language tag to set user's language
     mutating func updateUserLanguage(tag: String) throws {
         do {
-            try updateChatContext(with: [ChannelMetadataKeys.languageTag: tag])
+            try updateChatContext(with: [ChannelMetadataKeys.kmUserLocale: tag])
         } catch {
             throw error
         }


### PR DESCRIPTION
## Summary
- Added fix for SPM for SSL Pining. Created a check to use `KommunicateCore-Info` if in bundle the `KMExpectedPublicKeyHashBase64` is missing.
- Updated the User language update tag in metadata.