### PR TITLE
[CM-1814] If bot delay is set, Away message is not shown | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -164,7 +164,10 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
         // Hide away message view whenever a new message comes.
         // Make sure the message is not from same user.
         guard !viewModel.messageModels.isEmpty else { return }
-        if let lastMessage = viewModel.messageModels.last, !lastMessage.isMyMessage {
+        if let lastMessage = viewModel.messageModels.last,
+           !lastMessage.isMyMessage,
+           let currentAssignee = self.assigneeUserId,
+           lastMessage.contactId == currentAssignee {
             isAwayMessageViewHidden = true
         }
     }


### PR DESCRIPTION
## Summary
- Added a check for lastMessage Sent User ID and Conversation Assignee. If the value doesn't match the awayMessage UI will not get removed in New Message.

## Video

#### Before 

https://github.com/user-attachments/assets/24dcb9c1-9550-4bec-a5dd-c8be1bc80760

#### After 

https://github.com/user-attachments/assets/216d5e33-985d-4a86-af1a-4ff90af50ac1
