### PR TITLE
[CM-1186] Add preFilledMessage support to conversationObject | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversation.swift
+++ b/Sources/Kommunicate/Classes/KMConversation.swift
@@ -23,6 +23,7 @@ import KommunicateCore_iOS_SDK
     public var teamId: String?
     public var defaultConversationAssignee: String?
     public var appName: String? = Bundle.main.displayName
+    public var prefilledMessage: String? = nil
 
     public init(userId: String) {
         self.userId = userId
@@ -118,6 +119,14 @@ import KommunicateCore_iOS_SDK
     @discardableResult
     @objc public func withTeamId(_ teamId: String) -> KMConversationBuilder {
         conversation.teamId = teamId
+        return self
+    }
+    
+    /// To set pre fill message in Chat Bar while opening converwastion.
+    /// - Parameter message: Pass the text that should be vissble on chat bar while opening the conversation. Only works with `launchConversation`
+    @discardableResult
+    @objc public func setPreFilledMessage(_ messsage: String) -> KMConversationBuilder {
+        conversation.prefilledMessage = messsage
         return self
     }
 


### PR DESCRIPTION
### Summary
- Introduced a `prefilledMessage` parameter in the `KMConversation` object.
- Created a method to create and launch conversations. This method accepts a `KMConversation` object and a `UIViewController` as parameters.
- The `prefilledMessage` functionality is supported exclusively with the `launchConversation` method.

---

### Refactored Code
```swift
// Build a conversation object with a prefilled message
let kmConversation = KMConversationBuilder()
    .setPreFilledMessage("This is the Prefill message.")
    .build()

// Launch the conversation using the created conversation object
Kommunicate.launchConversation(conversation: kmConversation, viewController: self) { result in
    switch result {
    case .success(let conversationId):
        print("Successfully created conversation with ID: \(conversationId)")
    case .failure(let error):
        print("Failed to create a conversation: \(error)")
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a pre-filled message option in the chat bar for enhanced user experience.
	- Added a method to launch group chats directly from a specified view controller.

- **Bug Fixes**
	- Improved error handling and validation processes in the conversation launch functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->