### PR TITLE
[CM-2272] Fix the `registerUserAsVistor` name with `registerUserAsVisitor ` and Create Wrapper for old name | iOS SDK

### DIFF
--- a/Example/Kommunicate/LoginViewController.swift
+++ b/Example/Kommunicate/LoginViewController.swift
@@ -95,7 +95,7 @@
             setupApplicationKey(applicationId)
             let kmUser = userWithUserId(Kommunicate.randomId(), andApplicationId: applicationId)
             activityIndicator.startAnimating()
-            Kommunicate.registerUserAsVistor(kmUser, completion: {
+            Kommunicate.registerUserAsVisitor(kmUser, completion: {
                 response, error in
                 self.activityIndicator.stopAnimating()
                 guard error == nil else {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -266,7 +266,16 @@ open class Kommunicate: NSObject, Localizable {
         registerNewUser(kmUser, isVisitor: false, completion: completion)
     }
     
-    @objc open class func registerUserAsVistor(
+    /// Deprecated wrapper for backward compatibility
+    @available(*, deprecated, message: "Use `registerUserAsVisitor(_:completion:)` instead.")
+    @objc open class func registerUserAsVistor( // Note: Typo preserved intentionally
+        _ kmUser: KMUser = createVisitorUser(),
+        completion: @escaping (_ response: ALRegistrationResponse?, _ error: NSError?) -> Void
+    ) {
+        registerUserAsVisitor(kmUser, completion: completion)
+    }
+    
+    @objc open class func registerUserAsVisitor(
         _ kmUser: KMUser = createVisitorUser(),
         completion: @escaping (_ response: ALRegistrationResponse?, _ error: NSError?) -> Void
     ) {


### PR DESCRIPTION
## Summary
- Fixed the name of `registerUserAsVistor` with `registerUserAsVisitor`. 
- Made the code compatible with old name `registerUserAsVistor` as well.
- Added the deprecated label over the old function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user registration process with improved error handling and support for pre-chat lead collection settings.
	- Added a deprecated method for backward compatibility while introducing a corrected method for user registration.

- **Bug Fixes**
	- Corrected a typographical error in the user registration method name, ensuring proper functionality for visitor login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->