### PR TITLE
[CM-2277] SSL Pining Disabling Configuration | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/DataLoader.swift
+++ b/Sources/Kommunicate/Classes/DataLoader.swift
@@ -23,11 +23,13 @@ class DataLoader {
 
         // set up the session
         let config = URLSessionConfiguration.default
-        let session = URLSession(
-            configuration: config,
-            delegate: KMURLSessionPinningDelegate(),
-            delegateQueue: nil
-        )
+        let session: URLSession = {
+            if Kommunicate.isKMSSLPinningEnabled {
+                return URLSession(configuration: config, delegate: KMURLSessionPinningDelegate(), delegateQueue: nil)
+            } else {
+                return URLSession(configuration: config)
+            }
+        }()
 
         // make the request
         let task = session.dataTask(with: urlRequest) {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -83,6 +83,8 @@ open class Kommunicate: NSObject, Localizable {
         config.chatBar.optionsToShow = .some([.camera, .location, .gallery, .video, .document])
         return config
     }()
+    
+    public static var isKMSSLPinningEnabled: Bool = false
 
     /// Configuration which defines the behavior of ConversationView components.
     public static var kmConversationViewConfiguration = KMConversationViewConfiguration()
@@ -213,6 +215,7 @@ open class Kommunicate: NSObject, Localizable {
             assertionFailure("Kommunicate App ID: Empty value passed")
             return
         }
+        ALUserDefaultsHandler.setKMSSLPinningEnabled(isKMSSLPinningEnabled)
         guard KMUserDefaultHandler.isAppIdEmpty ||
             KMUserDefaultHandler.matchesCurrentAppId(applicationId)
         else {


### PR DESCRIPTION
## Summary
- Added the configuration to enable or disable the SSL pinning in the SDK. (By default the SSL Pinning is disabled)
- Updated the code to Bypass SSL Pining when configuration is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced SSL pinning control with a new setting option.
  - Added a pre-filled message feature for chat conversations.
  - Implemented a new method to launch conversations from a specified view controller.

- **Bug Fixes**
  - Enhanced error handling for network requests and parameters.

- **Documentation**
  - Updated comments for new properties and methods to clarify usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->