### PR TITLE
[CM-2280] AppSetting Api Call optimisation | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -121,6 +121,7 @@ open class Kommunicate: NSObject, Localizable {
     public static var presentingViewController = UIViewController()
     public static var leadArray = [LeadCollectionField]()
     static var embeddedViewController: String = ""
+    static let appSettingCache = KMCacheMemory<AppSetting>()
 
     public enum KommunicateError: Error {
         case notLoggedIn
@@ -342,7 +343,7 @@ open class Kommunicate: NSObject, Localizable {
     private class func registerNewUser(_ kmUser: KMUser, isVisitor : Bool, completion: @escaping (_ response: ALRegistrationResponse?, _ error: NSError?) -> Void) {
         
         let kmAppSetting = KMAppSettingService()
-        kmAppSetting.appSetting { result in
+        kmAppSetting.appSetting(forceRefresh: true) { result in
             switch result {
             case let .success(appSetting):
                 DispatchQueue.main.async {
@@ -988,7 +989,7 @@ open class Kommunicate: NSObject, Localizable {
      */
       @objc open class func isChatWidgetDisabled(completionHandler: @escaping (Bool) -> Void) {
         let appSettingsService = KMAppSettingService()
-        appSettingsService.appSetting {
+        appSettingsService.appSetting(forceRefresh: true) {
             result in
             switch result {
             case let .success(appSettings):

--- a/Sources/Kommunicate/Classes/Utilities/KMCacheMemory.swift
+++ b/Sources/Kommunicate/Classes/Utilities/KMCacheMemory.swift
@@ -1,0 +1,50 @@
+//
+//  KMCacheMemory.swift
+//  Kommunicate
+//
+//  Created by Abhijeet Ranjan on 07/01/25.
+//
+
+import Foundation
+
+class KMCacheMemory<T> {
+    // A dictionary to hold cached items and their expiry times.
+    private var cache: [String: (value: T, expiry: Date)] = [:]
+    private let queue = DispatchQueue(label: "com.kommunincate.cache.memory.queue", attributes: .concurrent)
+
+    /// This function is used to set cache data with a specified key and expiration time.
+    func setItem(forKey key: String, value: T, expiry: TimeInterval) {
+        let expiryDate = Date().addingTimeInterval(expiry)
+        queue.async(flags: .barrier) {
+            self.cache[key] = (value: value, expiry: expiryDate)
+        }
+    }
+
+    /// This function is used to retrieve data using the specified key.
+    func getItem(forKey key: String) -> T? {
+        queue.sync {
+            guard let cachedItem = cache[key] else { return nil }
+            if Date() > cachedItem.expiry {
+                // Remove the expired item
+                cache.removeValue(forKey: key)
+                return nil
+            }
+            return cachedItem.value
+        }
+    }
+
+    /// This function is used to remove a value using the specified key.
+    func removeItem(forKey key: String) {
+        queue.async(flags: .barrier) {
+            self.cache.removeValue(forKey: key)
+        }
+    }
+
+    /// This function clears all values stored in the cache memory.
+    func clear() {
+        queue.async(flags: .barrier) {
+            self.cache.removeAll()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Created cache memory that takes key value pair with expiry time.
- Added a check for cache data before having a api call if present shares the cache data.
- Created force update parameter for having a real time api call regardless of cache memory.
- The cache data is currently stored for 5 min.
- Used Force Update for - `registerNewUser` Function (required for PSEUDONYMS) , `isChatWidgetDisabled` Function (as this basically real time api call for disabling Widget) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a memory caching mechanism for app settings
	- Added ability to force-refresh app settings
	- Implemented thread-safe caching with expiration support

- **Performance Improvements**
	- Reduced unnecessary network calls by caching app settings
	- Enhanced data retrieval efficiency with configurable cache duration

- **Technical Enhancements**
	- Created a generic cache memory utility class
	- Added cache management methods for storing, retrieving, and clearing cached items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->