### PR TITLE
[CM-1564] Add .all in event list so every event will be included | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -1453,8 +1453,16 @@ open class Kommunicate: NSObject, Localizable {
      - events: list of events to subscribe.
      - callback: ALKCustomEventCallback to send subscribed event's data
      */
-    public static func subscribeCustomEvents(events: [KMCustomEvent], callback: ALKCustomEventCallback) {
-        KMCustomEventHandler.shared.setSubscribedEvents(eventsList: events, eventDelegate: callback)
+    public static func subscribeCustomEvents(events: [KMCustomEvent] = KMCustomEvent.allEvents, callback: ALKCustomEventCallback) {
+        let eventList: [KMCustomEvent]
+        
+        if events == KMCustomEvent.allEvents {
+            eventList = KMCustomEventHandler.shared.availableEvents()
+        } else {
+            eventList = events
+        }
+        
+        KMCustomEventHandler.shared.setSubscribedEvents(eventsList: eventList, eventDelegate: callback)
     }
     
     /*

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -1448,7 +1448,7 @@ open class Kommunicate: NSObject, Localizable {
     }
 
     /**
-     Subscribe Chat Events
+     Subscribe to chat events. Omit the events parameter to subscribe to all available events.
      - Parameters:
      - events: list of events to subscribe.
      - callback: ALKCustomEventCallback to send subscribed event's data


### PR DESCRIPTION
## Summary
- Updated the `subscribeCustomEvents` function to subscribe to all events if the user does not provide specific events.

## Code
 
- For Subscribing All Custom Events Available 
```swift
Kommunicate.subscribeCustomEvents(callback: self)

```

- For Subscribing Custom Events
```swift
let event: [KMCustomEvent] = [.richMessageClick, .faqClick, .messageSend, .messageReceive]
Kommunicate.subscribeCustomEvents(events: event, callback: self)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced event subscription method to automatically subscribe to all available events when no specific events are provided
	- Improved flexibility for custom event handling in the Kommunicate SDK

<!-- end of auto-generated comment: release notes by coderabbit.ai -->