### PR TITLE
[CM-2310] Add waiting Queue UI in SDK | iOS

### DIFF
--- a/Example/Kommunicate/Base.lproj/Localizable.strings
+++ b/Example/Kommunicate/Base.lproj/Localizable.strings
@@ -58,7 +58,7 @@ FaqTitle = "FAQ";
 
 /* Waiting Queue */
 waitingQueueTitle = "In queue...";
-waitingQueueMessage = "You are currently %@ in the waiting queue, our agents will get back you shortly.";
+waitingQueueMessage = "You are currently %@ in the waiting queue, our agents will get back to you shortly.";
 
 /* ApplozicSwift framework's key-value pairs */
 

--- a/Example/Kommunicate/Base.lproj/Localizable.strings
+++ b/Example/Kommunicate/Base.lproj/Localizable.strings
@@ -54,6 +54,12 @@ noName = "No Name";
 /* Navigation title for faq view controller */
 FaqTitle = "FAQ";
 
+
+
+/* Waiting Queue */
+waitingQueueTitle = "In queue...";
+waitingQueueMessage = "You are currently %@ in the waiting queue, our agents will get back you shortly.";
+
 /* ApplozicSwift framework's key-value pairs */
 
 Back = "Back";

--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -226,7 +226,6 @@ class ConversationVCNavBar: UIView, Localizable {
             onlineStatusIcon.isHidden = false
             profileView.isHidden = false
             waitingQueueText.isHidden = true
-            waitingQueueText.isHidden = true
         }
     }
 

--- a/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
+++ b/Sources/Kommunicate/Classes/ConversationVCNavBar.swift
@@ -96,6 +96,14 @@ class ConversationVCNavBar: UIView, Localizable {
         return label
     } ()
     
+    var waitingQueueText: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "HelveticaNeue", size: 20) ?? UIFont.systemFont(ofSize: 20)
+        label.textColor = UIColor(red: 113, green: 110, blue: 110)
+        label.isHidden = true
+        return label
+    }()
+    
     lazy var customSubtitleView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [])
         stackView.alignment = .leading
@@ -119,6 +127,7 @@ class ConversationVCNavBar: UIView, Localizable {
         static let offline = "offline"
         static let awayMode = "awayMode"
         static let noName = "noName"
+        static let waitingQueTitle = "waitingQueueTitle"
     }
 
     required init(
@@ -154,12 +163,14 @@ class ConversationVCNavBar: UIView, Localizable {
         let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [KMBaseNavigationViewController.self])
         if let textColor = navigationBarProxy.titleTextAttributes?[.foregroundColor] as? UIColor {
             profileName.textColor = textColor
+            waitingQueueText.textColor = textColor
             onlineStatusText.textColor = textColor
             customSubtitleText.textColor = textColor
             customRating.textColor = textColor
         }
         if let titleFont = navigationBarProxy.titleTextAttributes?[.font] as? UIFont {
             profileName.font = titleFont
+            waitingQueueText.font = titleFont
         }
         
         if let subtitleFont = navigationBarProxy.titleTextAttributes?[.subtitleFont] as? UIFont {
@@ -172,6 +183,11 @@ class ConversationVCNavBar: UIView, Localizable {
         }
         var subtitleText: String = ""
         var showCustomSubtitle: Bool = false
+        
+        waitingQueueText.text = localizedString(
+            forKey: LocalizationKey.waitingQueTitle,
+            fileName: localizationFileName
+        )
         
         if  !configuration.toolbarSubtitleText.isEmpty {
             customSubtitleView.addArrangedSubview(customSubtitleText)
@@ -196,9 +212,26 @@ class ConversationVCNavBar: UIView, Localizable {
         
         statusIconBackgroundColor.backgroundColor = navigationBarProxy.barTintColor
     }
+    
+    @objc func updateWaitingQueueUI(showWaitingQueueOnly: Bool) {
+        if showWaitingQueueOnly {
+            profileImage.isHidden = true
+            statusIconBackgroundColor.isHidden = true
+            onlineStatusIcon.isHidden = true
+            profileView.isHidden = true
+            waitingQueueText.isHidden = false
+        } else {
+            profileImage.isHidden = false
+            statusIconBackgroundColor.isHidden = false
+            onlineStatusIcon.isHidden = false
+            profileView.isHidden = false
+            waitingQueueText.isHidden = true
+            waitingQueueText.isHidden = true
+        }
+    }
 
     private func setupConstraints() {
-        addViewsForAutolayout(views: [backButton, profileImage, statusIconBackgroundColor, onlineStatusIcon, profileView])
+        addViewsForAutolayout(views: [backButton, waitingQueueText,profileImage, statusIconBackgroundColor, onlineStatusIcon, profileView])
 
         // Setup constraints
         backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: -10).isActive = true
@@ -206,6 +239,9 @@ class ConversationVCNavBar: UIView, Localizable {
         backButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10).isActive = true
         backButton.widthAnchor.constraint(equalToConstant: 20).isActive = true
 
+        waitingQueueText.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 20).isActive = true
+        waitingQueueText.topAnchor.constraint(equalTo: topAnchor, constant: 5).isActive = true
+        waitingQueueText.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5).isActive = true
         profileImage.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 10).isActive = true
         profileImage.topAnchor.constraint(equalTo: topAnchor, constant: 5).isActive = true
         profileImage.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5).isActive = true

--- a/Sources/Kommunicate/Classes/DataLoader.swift
+++ b/Sources/Kommunicate/Classes/DataLoader.swift
@@ -41,45 +41,6 @@ class DataLoader {
         }
         task.resume()
     }
-    
-    static func requestWithParameter(
-        url: URL,
-        params: [String: Any],
-        completion: @escaping (Result<Data, LoadingError>) -> Void)
-    {
-        var urlRequest = URLRequest(url: url)
-
-        urlRequest.httpMethod = "GET"
-        urlRequest.timeoutInterval = 600
-        urlRequest.setValue("Application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.setValue(KMUserDefaultHandler.getAuthToken(), forHTTPHeaderField: "X-Authorization")
-        urlRequest.setValue(KMUserDefaultHandler.getApplicationKey(), forHTTPHeaderField: "Application-Key")
-        guard let httpBody = try? JSONSerialization
-            .data(withJSONObject: params, options: .prettyPrinted)
-        else {
-            completion(.failure(.invalidParam))
-            return
-        }
-        // set up the session
-        let config = URLSessionConfiguration.default
-        let session: URLSession = {
-            if Kommunicate.isKMSSLPinningEnabled {
-                return URLSession(configuration: config, delegate: KMURLSessionPinningDelegate(), delegateQueue: nil)
-            } else {
-                return URLSession(configuration: config)
-            }
-        }()
-
-        // make the request
-        let task = session.dataTask(with: urlRequest) {
-            data, _, error in
-            let result = data.map(Result.success) ??
-                .failure(LoadingError.network(error))
-
-            completion(result)
-        }
-        task.resume()
-    }
 
     static func postRequest(
         url: URL,

--- a/Sources/Kommunicate/Classes/DataLoader.swift
+++ b/Sources/Kommunicate/Classes/DataLoader.swift
@@ -41,6 +41,45 @@ class DataLoader {
         }
         task.resume()
     }
+    
+    static func requestWithParameter(
+        url: URL,
+        params: [String: Any],
+        completion: @escaping (Result<Data, LoadingError>) -> Void)
+    {
+        var urlRequest = URLRequest(url: url)
+
+        urlRequest.httpMethod = "GET"
+        urlRequest.timeoutInterval = 600
+        urlRequest.setValue("Application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(KMUserDefaultHandler.getAuthToken(), forHTTPHeaderField: "X-Authorization")
+        urlRequest.setValue(KMUserDefaultHandler.getApplicationKey(), forHTTPHeaderField: "Application-Key")
+        guard let httpBody = try? JSONSerialization
+            .data(withJSONObject: params, options: .prettyPrinted)
+        else {
+            completion(.failure(.invalidParam))
+            return
+        }
+        // set up the session
+        let config = URLSessionConfiguration.default
+        let session: URLSession = {
+            if Kommunicate.isKMSSLPinningEnabled {
+                return URLSession(configuration: config, delegate: KMURLSessionPinningDelegate(), delegateQueue: nil)
+            } else {
+                return URLSession(configuration: config)
+            }
+        }()
+
+        // make the request
+        let task = session.dataTask(with: urlRequest) {
+            data, _, error in
+            let result = data.map(Result.success) ??
+                .failure(LoadingError.network(error))
+
+            completion(result)
+        }
+        task.resume()
+    }
 
     static func postRequest(
         url: URL,

--- a/Sources/Kommunicate/Classes/Extensions/URLBuilder+WaitingQueue.swift
+++ b/Sources/Kommunicate/Classes/Extensions/URLBuilder+WaitingQueue.swift
@@ -1,0 +1,16 @@
+//
+//  URLBuilder+WaitingQueue.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by Abhijeet Ranjan on 20/01/25.
+//
+
+import Foundation
+
+extension URLBuilder {
+    static func waitingQueueFor(teamID: String) -> URLBuilder {
+        let url = URLBuilder.chatApi.add(paths: ["rest", "ws", "group", "waiting", "list"])
+        url.add(item: "teamId", value: teamID)
+        return url
+    }
+}

--- a/Sources/Kommunicate/Classes/Extensions/URLBuilder+WaitingQueue.swift
+++ b/Sources/Kommunicate/Classes/Extensions/URLBuilder+WaitingQueue.swift
@@ -8,7 +8,16 @@
 import Foundation
 
 extension URLBuilder {
+    /// Returns a URLBuilder configured to fetch the waiting queue list for a specific team.
+    /// - Parameter teamID: The unique identifier of the team
+    /// - Returns: A configured URLBuilder instance
     static func waitingQueueFor(teamID: String) -> URLBuilder {
+        
+        guard !teamID.isEmpty else {
+            assertionFailure("teamID cannot be empty")
+            return URLBuilder.chatApi
+        }
+        
         let url = URLBuilder.chatApi.add(paths: ["rest", "ws", "group", "waiting", "list"])
         url.add(item: "teamId", value: teamID)
         return url

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -166,6 +166,41 @@ public class KMConversationService: KMConservationServiceable, Localizable {
             }
         })
     }
+    
+    func waitingQueueFor(
+        teamID: String,
+        completion: @escaping (Result<[Int], Error>) -> Void
+    ) {
+        guard let url = URLBuilder.waitingQueueFor(teamID: teamID).url else {
+            completion(.failure(APIError.urlBuilding))
+            return
+        }
+        let params: [String: Any] = ["teamId" : teamID] 
+        
+        DataLoader.requestWithParameter(url: url, params: params) { result in
+            switch result {
+            case let .success(data):
+                do {
+                    // Attempt to decode the JSON data
+                    guard let waitingQueData = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+                        print("Error: Unable to convert data to JSON")
+                        completion(.failure(APIError.jsonConversion))
+                        return
+                    }
+                    
+                    // Call the method to extract and process the response
+                    completion(self.extractWaitingQueResponse(from: waitingQueData))
+                } catch {
+                    // Handle JSON decoding errors
+                    print("Error decoding JSON: \(error.localizedDescription)")
+                    completion(.failure(APIError.jsonConversion))
+                }
+            case let .failure(error):
+                // Handle the network or request error
+                completion(.failure(error))
+            }
+        }
+    }
 
     @available(*, deprecated, message: "Use createConversation(conversation:completion:)")
     public func createConversation(
@@ -294,6 +329,22 @@ public class KMConversationService: KMConservationServiceable, Localizable {
             "message": message,
             "collectEmailOnAwayMessage": isAnonymousUser ? collectEmailOnAwayMessage : false
         ])
+    }
+
+    func extractWaitingQueResponse(from json: [String: Any]) -> Result<[Int], Error> {
+        guard
+            let status = json["status"] as? String, status == "success",
+            let response = json["response"] as? [Int]
+        else {
+            return .failure(APIError.jsonConversion)
+        }
+
+        // Ensure the response is not empty
+        if response.isEmpty {
+            return .failure(APIError.responseNotPresent)
+        }
+
+        return .success(response)
     }
 
     func agentIdFrom(json: [String: Any]) -> Result<String, Error> {

--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -175,9 +175,7 @@ public class KMConversationService: KMConservationServiceable, Localizable {
             completion(.failure(APIError.urlBuilding))
             return
         }
-        let params: [String: Any] = ["teamId" : teamID] 
-        
-        DataLoader.requestWithParameter(url: url, params: params) { result in
+        DataLoader.request(url: url) { result in
             switch result {
             case let .success(data):
                 do {

--- a/Sources/Kommunicate/Classes/KMErrors.swift
+++ b/Sources/Kommunicate/Classes/KMErrors.swift
@@ -50,7 +50,7 @@ public enum APIError: LocalizedError {
     case jsonConversion
     /// Thrown when last message is not present.
     case messageNotPresent
-    /// Thown when response is not in present.
+    /// Thrown when response is not present.
     case responseNotPresent
     /// Thrown in case of a network failure.
     /// - Parameter error: The underlying error object.

--- a/Sources/Kommunicate/Classes/KMErrors.swift
+++ b/Sources/Kommunicate/Classes/KMErrors.swift
@@ -50,6 +50,8 @@ public enum APIError: LocalizedError {
     case jsonConversion
     /// Thrown when last message is not present.
     case messageNotPresent
+    /// Thown when response is not in present.
+    case responseNotPresent
     /// Thrown in case of a network failure.
     /// - Parameter error: The underlying error object.
     case network(_ error: Error?)
@@ -69,6 +71,8 @@ public enum APIError: LocalizedError {
             } else {
                 errorMessage = "Failed to process API request"
             }
+        case .responseNotPresent:
+            errorMessage = "Failed while extracting response from the data."
         }
         return errorMessage
     }

--- a/Sources/Kommunicate/Classes/Models/ChatMessage.swift
+++ b/Sources/Kommunicate/Classes/Models/ChatMessage.swift
@@ -29,7 +29,8 @@ class ChatMessage: ALKChatViewModelProtocol, Localizable {
     var isMessageEmpty: Bool
     var platformSource: String?
     var assignedTags: [KMAssignedTags]?
-
+    var isWatingQueueConversation: Bool
+    
     init(message: ALKChatViewModelProtocol) {
         avatar = message.avatar
         avatarImage = message.avatarImage
@@ -47,6 +48,7 @@ class ChatMessage: ALKChatViewModelProtocol, Localizable {
         messageType = message.messageType
         isMessageEmpty = message.isMessageEmpty
         platformSource = message.platformSource
+        isWatingQueueConversation = message.isWatingQueueConversation
 
         // Update message to show conversation assignee details
         let (_, channel) = ConversationDetail().conversationAssignee(groupId: channelKey, userId: contactId)

--- a/Sources/Kommunicate/Classes/Models/ChatMessage.swift
+++ b/Sources/Kommunicate/Classes/Models/ChatMessage.swift
@@ -29,7 +29,7 @@ class ChatMessage: ALKChatViewModelProtocol, Localizable {
     var isMessageEmpty: Bool
     var platformSource: String?
     var assignedTags: [KMAssignedTags]?
-    var isWatingQueueConversation: Bool
+    var isWaitingQueueConversation: Bool
     
     init(message: ALKChatViewModelProtocol) {
         avatar = message.avatar
@@ -48,7 +48,7 @@ class ChatMessage: ALKChatViewModelProtocol, Localizable {
         messageType = message.messageType
         isMessageEmpty = message.isMessageEmpty
         platformSource = message.platformSource
-        isWatingQueueConversation = message.isWatingQueueConversation
+        isWaitingQueueConversation = message.isWaitingQueueConversation
 
         // Update message to show conversation assignee details
         let (_, channel) = ConversationDetail().conversationAssignee(groupId: channelKey, userId: contactId)

--- a/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
+++ b/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
@@ -15,6 +15,7 @@ class AwayMessageView: UIView , Localizable {
         private static let filename = Kommunicate.defaultConfiguration.localizedStringFileName
         static let CollectEmailMessageOnAwayMode = localizedString(forKey: "CollectEmailMessageOnAwayMode", fileName: filename)
         static let InvalidEmailMessageOnAwayMode = localizedString(forKey: "InvalidEmailMessageOnAwayMode", fileName: filename)
+        static let WaitingQueueMessage = localizedString(forKey: "waitingQueueMessage", fileName: filename)
     }
     
     enum ConstraintIdentifier: String {
@@ -117,6 +118,10 @@ class AwayMessageView: UIView , Localizable {
 
     func set(message: String) {
         messageLabel.text = message
+    }
+    
+    func setWaitingQueueMessage(count: Int) {
+        messageLabel.text = String(format: LocalizedText.WaitingQueueMessage, "#\(count)")
     }
 
     func drawDottedLines() {

--- a/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
+++ b/Sources/Kommunicate/Classes/Views/AwayMessageView.swift
@@ -120,8 +120,10 @@ class AwayMessageView: UIView , Localizable {
         messageLabel.text = message
     }
     
+    /// Updates the message label to display the user's position in the waiting queue.
+    /// - Parameter count: The user's position number in the queue
     func setWaitingQueueMessage(count: Int) {
-        messageLabel.text = String(format: LocalizedText.WaitingQueueMessage, "#\(count)")
+        messageLabel.text = String(format: LocalizedText.WaitingQueueMessage, "#" + String(count))
     }
 
     func drawDottedLines() {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added waiting queue functionality to conversations
	- Introduced localized strings for waiting queue status
	- Enhanced UI to display user's position in the waiting queue

- **Bug Fixes**
	- Added error handling for response-related scenarios

- **Documentation**
	- Improved error message descriptions

The changes introduce a comprehensive waiting queue system that provides users with clear information about their conversation status and position in the queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Images

<img src = 'https://github.com/user-attachments/assets/6b26ecde-7e4a-4a1f-8514-d0e6a60a5445' height = 360> <img src = 'https://github.com/user-attachments/assets/e655235c-2f4b-4682-a2b1-d395614ced98' height = 360>