### PR TITLE
Fixed the issue of conversation restart not working properly.

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -572,9 +572,9 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
             if let channelId = weakSelf.viewModel.channelKey {
                 KMCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.restartConversationClick, data: ["conversationId":channelId])
             }
+            guard let zendeskAcckountKey = ALApplozicSettings.getZendeskSdkAccountKey(),
+                  !zendeskAcckountKey.isEmpty else { return }
             #if canImport(ChatProvidersSDK)
-                guard let zendeskAcckountKey = ALApplozicSettings.getZendeskSdkAccountKey(),
-                      !zendeskAcckountKey.isEmpty else { return }
                 // if zendesk is integrated, create a new conversation instead of restarting the conversation
                 let zendeskHandler = KMZendeskChatHandler.shared
                 zendeskHandler.resetConfiguration()

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -572,8 +572,8 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
             if let channelId = weakSelf.viewModel.channelKey {
                 KMCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.restartConversationClick, data: ["conversationId":channelId])
             }
-            guard let zendeskAcckountKey = ALApplozicSettings.getZendeskSdkAccountKey(),
-                  !zendeskAcckountKey.isEmpty else { return }
+            guard let zendeskAccountKey = ALApplozicSettings.getZendeskSdkAccountKey(),
+                  !zendeskAccountKey.isEmpty else { return }
             #if canImport(ChatProvidersSDK)
                 // if zendesk is integrated, create a new conversation instead of restarting the conversation
                 let zendeskHandler = KMZendeskChatHandler.shared

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -578,7 +578,7 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
                 // if zendesk is integrated, create a new conversation instead of restarting the conversation
                 let zendeskHandler = KMZendeskChatHandler.shared
                 zendeskHandler.resetConfiguration()
-                zendeskHandler.initiateZendesk(key: zendeskAcckountKey)
+                zendeskHandler.initiateZendesk(key: zendeskAccountKey)
             #endif
             weakSelf.loadingStarted()
             // Create a new conversation 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- The condition failed because the Zendesk check enforced case sensitivity while validating the Zendesk key, which either enables the creation of a new Zendesk-enabled conversation or exits if the key is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversation handling logic to validate Zendesk account key more consistently across different SDK configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->