### PR TITLE
[CM-1707] Hide Start new conversation button on list screen when issinglethreaded is set to true

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -35,6 +35,8 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
 
     public var dbService = ALMessageDBService()
     public var viewModel = ALKConversationListViewModel()
+    
+    var isSingleThreadedEnabled = ALApplozicSettings.getIsSingleThreadedEnabled()
 
     enum Padding {
         enum NoConversationLabel {
@@ -81,7 +83,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
         let darkTitleColor = kmConversationViewConfiguration.startNewConversationButtonDarkTextColor ?? kmConversationViewConfiguration.startNewConversationButtonTextColor
         button.setTitleColor(UIColor.kmDynamicColor(light: kmConversationViewConfiguration.startNewConversationButtonTextColor, dark: darkTitleColor), for: .normal)
         button.isUserInteractionEnabled = true
-        if configuration.hideBottomStartNewConversationButton {
+        if configuration.hideBottomStartNewConversationButton || isSingleThreadedEnabled {
             button.isHidden = true
         }
         return button
@@ -190,6 +192,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
         super.viewDidLoad()
         setupMqtt()
         subscribeToConversation()
+        isSingleThreadedEnabled = ALApplozicSettings.getIsSingleThreadedEnabled()
         dbService.delegate = self
         viewModel.delegate = self
         setupSearchController()
@@ -241,7 +244,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
             noConversationLabel.topAnchor.constraint(equalTo: startNewButton.bottomAnchor, constant: 10.0).isActive = true
         }
        
-        if !configuration.hideBottomStartNewConversationButton  {
+        if !(configuration.hideBottomStartNewConversationButton || isSingleThreadedEnabled)  {
             startNewConversationBottomButton.centerXAnchor.constraint(equalTo: backgroundView.centerXAnchor).isActive = true
             startNewConversationBottomButton.widthAnchor.constraint(equalToConstant: Padding.startNewConversationButton.width).isActive = true
             startNewConversationBottomButton.heightAnchor.constraint(equalToConstant: Padding.startNewConversationButton.height).isActive = true
@@ -519,6 +522,9 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
         view.isUserInteractionEnabled = true
         conversationListTableViewController.tableView.isHidden = show
         noConversationLabel.isHidden = !show
+        if configuration.hideBottomStartNewConversationButton || isSingleThreadedEnabled {
+            startNewConversationBottomButton.isHidden = true
+        }
         startNewButton.isHidden = configuration.hideEmptyStateStartNewButtonInConversationList
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Added the check to verify is Single Threaded conversation condition is enabled from dashboard on basis of that hiding the Bottom Start New Conversation button.

## Testing Branches
<!-- How was the code tested? Be as specific as possible. -->
KM_ChatUI_Branch : `dev`
KM_Core_Branch: `dev`