### PR TITLE
[CM-2338] Show Typing Indicator in Bot Messages till Bot Replies | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/KMAppSettingsResponse.swift
+++ b/Sources/Kommunicate/Classes/KMAppSettingsResponse.swift
@@ -47,6 +47,7 @@ struct ChatWidgetResponse: Decodable {
     let pseudonymsEnabled : Bool?
     let csatRatingBase : Int?
     let disableChatWidget : Bool?
+    let botTypingIndicatorInterval: Int?
 }
 
 struct DefaultUploadOverride: Decodable {

--- a/Sources/Kommunicate/Classes/KMAppSettingsService.swift
+++ b/Sources/Kommunicate/Classes/KMAppSettingsService.swift
@@ -67,6 +67,7 @@ class KMAppSettingService {
                }
 
        KMAppUserDefaultHandler.shared.botMessageDelayInterval = chatWidget.botMessageDelayInterval ?? 0
+       KMAppUserDefaultHandler.shared.botTypingIndicatorInterval = chatWidget.botTypingIndicatorInterval ?? 0
        KMAppUserDefaultHandler.shared.csatRatingBase = chatWidget.csatRatingBase ?? 3
        
        guard let primaryColor = chatWidget.primaryColor else {
@@ -92,6 +93,7 @@ class KMAppSettingService {
        appSettings.defaultUploadOverrideUrl = chatWidget.defaultUploadOverride?.url ?? ""
        appSettings.defaultUploadOverrideHeaders = chatWidget.defaultUploadOverride?.headers ?? [:]
        appSettings.csatRatingBase = chatWidget.csatRatingBase ?? 3
+       appSettings.botTypingIndicatorInterval = chatWidget.botTypingIndicatorInterval ?? 0
        appSettingsUserDefaults.updateOrSetAppSettings(appSettings: appSettings)
     }
 

--- a/Sources/Kommunicate/Classes/KMAppUserDefaultHandler.swift
+++ b/Sources/Kommunicate/Classes/KMAppUserDefaultHandler.swift
@@ -38,7 +38,14 @@ class KMAppUserDefaultHandler: NSObject {
             return userDefaultSuite.integer(forKey: Key.CSATRatingBase)
         }
     }
-
+    var botTypingIndicatorInterval: Int {
+        set {
+            userDefaultSuite.set(newValue, forKey: Key.BotTypingIndicatorInterval)
+        }
+        get {
+            return userDefaultSuite.integer(forKey: Key.BotTypingIndicatorInterval)
+        }
+    }
     private let userDefaultSuite: UserDefaults
 
     init(userDefaultSuite: UserDefaults) {
@@ -63,5 +70,6 @@ private extension KMAppUserDefaultHandler {
         static let CSATEnabled = "CSAT_ENABLED"
         static let BotMessageDelayInterval = "BOT_MESSAGE_DELAY_INTERVAL"
         static let CSATRatingBase = "CSAT_RATTING_BASE"
+        static let BotTypingIndicatorInterval = "BOT_TYPING_INDICATOR_INTERVAL"
     }
 }


### PR DESCRIPTION
## Summary
- Added Typing Indicator `botTypingIndicatorInterval` Value check in App Settings api call.

## Testing Branches
<!-- How was the code tested? Be as specific as possible. -->
KM_ChatUI_Branch : `CM-2338`
KM_Core_Branch: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option for the chat widget that lets you control the delay before the bot's typing indicator appears, contributing to a more natural and engaging messaging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->