### PR TITLE
[CM-2385] Disable Restart Conversation through Submit button | iOS SDK 

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -717,6 +717,7 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
     override open func sendQuickReply(_ text: String,
                                       metadata: [String: Any]?,
                                       languageCode language: String?) {
+        guard isConversationResolvedAndReplyEnabled() else { return }
         do {
             var replyMetadata = metadata ?? [String: Any]() // reply meta data
 


### PR DESCRIPTION
## Summary
- Added the code to disable the Submit button when the Restart Conversation button is disabled.

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `CM-2385`
KM_Core_Branch: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved quick reply behavior so that messages are only sent when the conversation is active and replying is allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->