### PR TITLE
[CM-2363] AL Prefix Removal from File name And Function Name | iOS SDK

### DIFF
--- a/Example/Tests/KommunicateTests.swift
+++ b/Example/Tests/KommunicateTests.swift
@@ -33,12 +33,12 @@ class KommunicateTests: XCTestCase {
         }
     }
 
-    class ApplozicClientMock: ApplozicClient {
+    class KommunicateClientMock: KommunicateClient {
         static var messageCount = 1
 
         override func getLatestMessages(_: Bool, withCompletionHandler completion: ((NSMutableArray?, Error?) -> Void)!) {
             let messageList: NSMutableArray = []
-            for _ in 0 ..< ApplozicClientMock.messageCount {
+            for _ in 0 ..< KommunicateClientMock.messageCount {
                 let message = ALMessage()
                 messageList.add(message)
             }
@@ -89,7 +89,7 @@ class KommunicateTests: XCTestCase {
 
              // Test when multiple threads are present, method to show conversation list
              // gets called.
-             ApplozicClientMock.messageCount = 2
+             KommunicateClientMock.messageCount = 2
              KommunicateMock.createAndShowConversation(from: dummyViewController, completion: {
                  _ in
                  XCTAssertTrue(KommunicateMock.showConversationsCalled)
@@ -107,7 +107,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testCreateConversationWithCustomData() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         
         for bundle in Bundle.allBundles {
@@ -155,7 +155,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testCreateAndLaunchConversationWithCustomData() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         
         for bundle in Bundle.allBundles {
@@ -211,7 +211,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testUpdateConversationAssignee() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         let assigneeId = "alex-nwqih"
 
@@ -261,7 +261,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testUpdateTeamID() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         let teamID = "107732724"
 
@@ -311,7 +311,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testUpdateConversationMetadata() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         let metaData = ["name": "Alice", "city": "London", "hobby": "Painting"]
 
@@ -361,7 +361,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testSendMessageFunction() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         
         let kmConversation = KMConversationBuilder()
@@ -417,7 +417,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testOpenPerticularConversation() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         
         // Dummy View Controller For Testing
@@ -456,7 +456,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testUpdateConversationFunction() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         
         let kmConversation = KMConversationBuilder()
@@ -531,7 +531,7 @@ class KommunicateTests: XCTestCase {
     }
     
     func testIsSingleThreaded() {
-        KommunicateMock.applozicClientType = ApplozicClientMock.self
+        KommunicateMock.applozicClientType = KommunicateClientMock.self
         let expectation = self.expectation(description: "Completion handler called")
         let kmConversation = KMConversationBuilder()
             .useLastConversation(true)

--- a/Sources/Kommunicate/Classes/ConversationDetail.swift
+++ b/Sources/Kommunicate/Classes/ConversationDetail.swift
@@ -56,7 +56,7 @@ class ConversationDetail {
                 completion(contact, alChannel)
                 return
             }
-            for case let userDetail as ALUserDetail in userDetails {
+            for case let userDetail as KMCoreUserDetail in userDetails {
                 strongSelf.contactDbService.update(userDetail)
             }
             (assignee, alChannel) = strongSelf.conversationAssignee(groupId: groupId, userId: userId)

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -781,7 +781,7 @@ extension KMConversationListViewController: ALMQTTConversationDelegate {
 
     open func reloadData(forUserBlockNotification userId: String!, andBlockFlag _: Bool) {
         print("reload data")
-        let userDetail = ALUserDetail()
+        let userDetail = KMCoreUserDetail()
         userDetail.userId = userId
         viewModel.updateStatusFor(userDetail: userDetail)
         guard let viewController = navigationController?.visibleViewController as? KMConversationViewController else {
@@ -790,7 +790,7 @@ extension KMConversationListViewController: ALMQTTConversationDelegate {
         viewController.checkUserBlock()
     }
 
-    open func updateLastSeen(atStatus alUserDetail: ALUserDetail!) {
+    open func updateLastSeen(atStatus alUserDetail: KMCoreUserDetail!) {
         print("Last seen updated")
         viewModel.updateStatusFor(userDetail: alUserDetail)
         guard let viewController = navigationController?.visibleViewController as? KMConversationViewController else {

--- a/Sources/Kommunicate/Classes/Kommunicate.swift
+++ b/Sources/Kommunicate/Classes/Kommunicate.swift
@@ -223,7 +223,7 @@ open class Kommunicate: NSObject, Localizable {
         return isJailbroken
     }
 
-    static var applozicClientType: ApplozicClient.Type = ApplozicClient.self
+    static var applozicClientType: KommunicateClient.Type = KommunicateClient.self
 
     override public init() {
         super.init()


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Updated ApplozicClient and ALUserDetail
- And updated test variable name ApplozicClientMock to KommunicateClientMock

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `CM-2363`
KM_Core_Branch: `CM-2363`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test component naming to ensure consistency in internal references.
  
- **Refactor**
  - Standardized user detail types in conversation handling components.
  - Updated client type references to improve internal consistency without changing visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->