### PR TITLE
[CM-1628] 256 char limit for CX and ES not working allowing for 2000 char | iOS SDK 

### DIFF
--- a/Sources/Kommunicate/Classes/BotDetailResponse.swift
+++ b/Sources/Kommunicate/Classes/BotDetailResponse.swift
@@ -25,6 +25,7 @@ struct BotDetailResponse: Decodable, BotDetailResponseProtocol {
 
 public struct BotDetail: Decodable {
     let aiPlatform: String?
+    let dialogflowCXBot: Bool?
 }
 
 extension BotDetailResponse {
@@ -35,6 +36,8 @@ extension BotDetailResponse {
         case RASA = "rasa"
         case SMARTREPLY = "smartreply"
         case CUSTOM = "custom"
+        case DIALOGFLOWCX = "dialogflowcx"
+        case DIALOGFLOWES = "dialogflowes"
     }
 
     init(data: Data) throws {

--- a/Sources/Kommunicate/Classes/Controllers/KMConversationController+MessageCharacterLimit.swift
+++ b/Sources/Kommunicate/Classes/Controllers/KMConversationController+MessageCharacterLimit.swift
@@ -18,16 +18,30 @@ extension KMConversationViewController: MessageCharacterLimitDelegate {
     }
 
     func characterLimit(manager _: MessageCharacterLimitManager, reachedTheLimit _: Int, textCount: Int) {
-        let messageLimit = CharacterLimit.charlimit
-        let botLimit = CharacterLimit.botCharLimit
-        if isConversationAssignedToDialogflowBot, textCount >= botLimit.soft, textCount <= messageLimit.soft {
-            botCharLimitManager.messageToShow = characterLimitMessage(textCount: textCount, limit: botLimit, isMessageforBot: true)
-            botCharLimitManager.showLimitView(true, disableButton: textCount > botLimit.hard)
-        } else if textCount >= messageLimit.soft {
-            messageCharLimitManager.messageToShow = characterLimitMessage(textCount: textCount, limit: messageLimit, isMessageforBot: false)
-            messageCharLimitManager.showLimitView(true, disableButton: textCount > messageLimit.hard)
+        let limitConfig = determineCharacterLimit()
+        handleCharacterLimit(textCount: textCount, limit: limitConfig.limit, manager: limitConfig.manager, isBotMessage: limitConfig.isBotMessage)
+    }
+
+    private func determineCharacterLimit() -> (limit: CharacterLimit.Limit, manager: MessageCharacterLimitManager, isBotMessage: Bool) {
+        switch (isConversationAssignedToDialogflowBot, isConversationAssignedToDialogflowCXBot) {
+        case (true, true):
+            return (CharacterLimit.cxBotCharLimit, botCharLimitManager, true) /// Conversation is assigned to Dialogflow CX bot
+        case (true, false):
+            return (CharacterLimit.botCharLimit, botCharLimitManager, true)  /// Conversation is assigned to Dialogflow ES bot
+        default:
+            return (CharacterLimit.charlimit, messageCharLimitManager, false) /// Conversation is assigned to Non - Dialogflow bot
+        }
+    }
+
+    private func handleCharacterLimit(textCount: Int, limit: CharacterLimit.Limit, manager: MessageCharacterLimitManager, isBotMessage: Bool) {
+        let hasReachedSoftLimit = textCount >= limit.soft
+        let hasExceededHardLimit = textCount > limit.hard
+        
+        if hasReachedSoftLimit {
+            manager.messageToShow = characterLimitMessage(textCount: textCount, limit: limit, isMessageforBot: isBotMessage)
+            manager.showLimitView(true, disableButton: hasExceededHardLimit)
         } else {
-            messageCharLimitManager.showLimitView(false)
+            manager.showLimitView(false)
         }
     }
 }

--- a/Sources/Kommunicate/Classes/KMAppUserDefaultHandler.swift
+++ b/Sources/Kommunicate/Classes/KMAppUserDefaultHandler.swift
@@ -69,6 +69,18 @@ class KMAppUserDefaultHandler: NSObject {
     func getBotType(botId: String) -> String? {
         return userDefaultSuite.value(forKey: botId) as? String
     }
+    
+    func setDialogFlowBotType(_ botType: String, botId: String) {
+        guard !botType.isEmpty, !botId.isEmpty else { return }
+        let key = "dialogflow_\(botId)"
+        userDefaultSuite.setValue(botType, forKey: key)
+    }
+
+    func getDialogFlowBotType(botId: String) -> String? {
+        guard !botId.isEmpty else { return nil }
+        let key = "dialogflow_\(botId)"
+        return userDefaultSuite.value(forKey: key) as? String
+    }
 
     func clear() {
         userDefaultSuite.removePersistentDomain(forName: KMAppUserDefaultHandler.defaultSuiteName)

--- a/Sources/Kommunicate/Classes/KMBotService.swift
+++ b/Sources/Kommunicate/Classes/KMBotService.swift
@@ -50,6 +50,13 @@ public struct KMBotService {
                     print("Bot detail fetched successfully for botId:\(botId) And Bot platform:", botDetail.aiPlatform as Any)
                     /// Add the botType and botId in user defaults
                     DispatchQueue.main.async {
+                        if botType == BotDetailResponse.BotType.DIALOGFLOW.rawValue {
+                            if let isCXBot = botDetail.dialogflowCXBot, isCXBot {
+                                KMAppUserDefaultHandler.shared.setDialogFlowBotType(BotDetailResponse.BotType.DIALOGFLOWCX.rawValue, botId: botId)
+                            } else {
+                                KMAppUserDefaultHandler.shared.setDialogFlowBotType(BotDetailResponse.BotType.DIALOGFLOWES.rawValue, botId: botId)
+                            }
+                        }
                         KMAppUserDefaultHandler.shared.setBotType(botType, botId: botId)
                         completion(.success(botDetail))
                     }
@@ -122,5 +129,15 @@ public struct KMBotService {
                 }
             }
         }
+    }
+    
+    func isCXDialogFlowBot(type: String, groupId: NSNumber) -> Bool? {
+        guard let assigneeId = assigneeUserIdFor(groupId: groupId),
+              let channelUserX = channelDBService.loadChannelUserX(byUserId: groupId, andUserId: assigneeId),
+              channelUserX.role == 2
+        else {
+            return nil
+        }
+        return KMAppUserDefaultHandler.shared.getDialogFlowBotType(botId: assigneeId) == type
     }
 }

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -81,6 +81,7 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
             }
         }
     }
+    var isConversationAssignedToDialogflowCXBot = false
 
     let awayMessageheight = 80.0
 
@@ -1123,7 +1124,12 @@ extension KMConversationViewController {
 
     func conversationAssignedToDialogflowBot() {
         guard let channelKey = viewModel.channelKey else { return }
-        kmBotService.conversationAssignedToBotForBotType(type: BotDetailResponse.BotType.DIALOGFLOW.rawValue, groupId: channelKey) { [weak self] isDialogflowBot in
+        kmBotService.conversationAssignedToBotForBotType(type: BotDetailResponse.BotType.DIALOGFLOW.rawValue, groupId: channelKey) {
+            [weak self] isDialogflowBot in
+            if isDialogflowBot,
+               let isCXBot = self?.kmBotService.isCXDialogFlowBot(type: BotDetailResponse.BotType.DIALOGFLOWCX.rawValue, groupId: channelKey) {
+                self?.isConversationAssignedToDialogflowCXBot = isCXBot
+            }
 
             self?.isConversationAssignedToDialogflowBot = isDialogflowBot
             guard let weakSelf = self,

--- a/Sources/Kommunicate/Classes/Utilities/CharacterLimit.swift
+++ b/Sources/Kommunicate/Classes/Utilities/CharacterLimit.swift
@@ -19,7 +19,8 @@ public enum CharacterLimit: Localizable {
     }
 
     public static var charlimit = Limit(soft: 1800, hard: 2000)
-    public static var botCharLimit = Limit(soft: 55, hard: 256)
+    public static var botCharLimit = Limit(soft: 200, hard: 256)
+    public static var cxBotCharLimit = Limit(soft: 450, hard: 500)
 
     enum LocalizedText {
         private static let filename = Kommunicate.defaultConfiguration.localizedStringFileName


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Added Identifier for CX and ES Dialog Flow bot. 
- According to that added the limitation for `CX -> 500` limit and for `ES -> 250` limit.
- Updated the soft limitation value for `CX -> 450` limit and for `ES -> 200` limit. (As per Web Widget)

## Image (CX - ES)

<img src ='https://github.com/user-attachments/assets/7f8bc540-5162-4317-9287-4d69b2b830af' height = '300'> <img src ='https://github.com/user-attachments/assets/a66d9040-dfdc-4c68-8981-5526c9c22538' height = '300'> 

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `dev`
KM_Core_Branch: `dev`