### PR TITLE
[CM-1289] Expose Events with correct data to endusers | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
+++ b/Sources/Kommunicate/Classes/Views/FeedbackRatingView.swift
@@ -72,6 +72,7 @@ class FeedbackRatingView: UIView {
 
     private func setupView() {
         onRatingTap = { [weak self] tag in
+            ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.rateConversationEmotionsClicked, data: ["rating": tag])
             self?.selectedRatingTag = tag
         }
         ratingButtons.forEach { $0.ratingTapped = onRatingTap }

--- a/Sources/Kommunicate/Classes/Views/KMFiveStarView.swift
+++ b/Sources/Kommunicate/Classes/Views/KMFiveStarView.swift
@@ -69,6 +69,7 @@ class KMFiveStarView: UIView {
     @objc private func starTapped(_ sender: UIButton) {
         rating = sender.tag + 1
         ratingDidChange?(rating)
+        ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.rateConversationEmotionsClicked, data: ["rating": rating])
     }
         
     private func updateStars() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Exposed `currentOpenedConversation` , `videoButtonClicked`, `cameraButtonClicked`, `rateConversationEmotionsClicked`, `locationButtonClicked`, `voiceButtonClicked` and `attachmentOptionClicked`.
## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `CM-1289`
KM_Core_Branch: `dev`