### PR TITLE
[CM-2330] Pass language code from IOS in both format "en" and "en_US" - lex bot requirement

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationService.swift
+++ b/Sources/Kommunicate/Classes/KMConversationService.swift
@@ -469,6 +469,13 @@ public class KMConversationService: KMConservationServiceable, Localizable {
         }
         updateMetadataChatContext(info: [ChannelMetadataKeys.kmUserLocale: languageCode as Any], metadata: metadata)
         
+        /// For Dialogflow bot, pass language code with region using key `kmUserLanguageCode`
+        if let languageCodeWithRegion = [Locale.current.languageCode, Locale.current.regionCode]
+            .compactMap({ $0 })
+            .joined(separator: "_") as String?, !languageCodeWithRegion.isEmpty {
+            updateMetadataChatContext(info: [ChannelMetadataKeys.languageTag: languageCodeWithRegion as Any], metadata: metadata)
+        }
+
         guard let messageMetadata = Kommunicate.defaultConfiguration.messageMetadata,
               !messageMetadata.isEmpty
         else {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Added the Code for Dialogflow bot, pass language code with region using key `kmUserLanguageCode`

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `CM-2330`
KM_Core_Branch: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced chat context metadata to include the user's full language and region code for Dialogflow bots, improving language-specific experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->