### PR TITLE
[CM-2439] Update UI Message to Indicate Subscription Requirement in Release Mode | iOS SDK

### DIFF
--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -486,7 +486,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
     }
 
     override public func showAccountSuspensionView() {
-        let accountVC = ALKAccountSuspensionController()
+        let accountVC = ALKAccountSuspensionController(configuration: configuration)
         present(accountVC, animated: true, completion: nil)
         accountVC.isModalInPresentation = true
         accountVC.closePressed = { [weak self] in
@@ -621,7 +621,7 @@ public class KMConversationListViewController: ALKBaseViewController, Localizabl
     }
 
     private func checkPlanAndShowSuspensionScreen() {
-        let accountVC = ALKAccountSuspensionController()
+        let accountVC = ALKAccountSuspensionController(configuration: configuration)
         accountVC.isModalInPresentation = true
         guard PricingPlan.shared.showSuspensionScreen() else { return }
         present(accountVC, animated: true, completion: nil)

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -827,8 +827,8 @@ open class KMConversationViewController: ALKConversationViewController, KMUpdate
     }
 
     private func checkPlanAndShowSuspensionScreen() {
-        let accountVC = ALKAccountSuspensionController()
-        accountVC.isModalInPresentation = true 
+        let accountVC = ALKAccountSuspensionController(configuration: configuration)
+        accountVC.isModalInPresentation = true
         guard PricingPlan.shared.showSuspensionScreen() else { return }
         present(accountVC, animated: true, completion: nil)
         accountVC.closePressed = { [weak self] in

--- a/Sources/Kommunicate/Classes/PricingPlan.swift
+++ b/Sources/Kommunicate/Classes/PricingPlan.swift
@@ -19,6 +19,7 @@ struct PricingPlan {
     let startupPlan = 101
     let startMonthlyPlan = 112
     let startYearlyPlan = 113
+    let trialPlan = 111
     
     // Business Plans
     let businessPlans = ["trial",
@@ -41,11 +42,17 @@ struct PricingPlan {
 
     func showSuspensionScreen() -> Bool {
         let isReleaseBuild = !utility.isThisDebugBuild()
-        let isFreePlan = userDefaultsHandler.getUserPricingPackage() == startupPlan
-        let isStartPlan = (userDefaultsHandler.getUserPricingPackage() == startMonthlyPlan || userDefaultsHandler.getUserPricingPackage() == startYearlyPlan)
-        let isNotAgent = userDefaultsHandler.getUserRoleType() != Int16(AL_APPLICATION_WEB_ADMIN.rawValue)
-        guard isReleaseBuild, isNotAgent, isFreePlan || isStartPlan else { return false }
-        return true
+        let userPlan = userDefaultsHandler.getUserPricingPackage()
+        let userRole = userDefaultsHandler.getUserRoleType()
+        
+        let isFreeOrStartOrTrialPlan: Bool = {
+            let startPlans = [startMonthlyPlan, startYearlyPlan]
+            return userPlan == startupPlan || startPlans.contains(Int(userPlan)) || userPlan == trialPlan
+        }()
+        
+        let isNotAdmin = userRole != Int16(AL_APPLICATION_WEB_ADMIN.rawValue)
+        
+        return isReleaseBuild && isNotAdmin && isFreeOrStartOrTrialPlan
     }
     
     func isBusinessPlanOrTrialPlan() -> Bool {

--- a/Sources/Kommunicate/Classes/PricingPlan.swift
+++ b/Sources/Kommunicate/Classes/PricingPlan.swift
@@ -20,6 +20,7 @@ struct PricingPlan {
     let startMonthlyPlan = 112
     let startYearlyPlan = 113
     let trialPlan = 111
+    let churnedPlan = 100
     
     // Business Plans
     let businessPlans = ["trial",
@@ -47,7 +48,7 @@ struct PricingPlan {
         
         let isFreeOrStartOrTrialPlan: Bool = {
             let startPlans = [startMonthlyPlan, startYearlyPlan]
-            return userPlan == startupPlan || startPlans.contains(Int(userPlan)) || userPlan == trialPlan
+            return userPlan == startupPlan || startPlans.contains(Int(userPlan)) || userPlan == trialPlan || userPlan == churnedPlan
         }()
         
         let isNotAdmin = userRole != Int16(AL_APPLICATION_WEB_ADMIN.rawValue)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Updated the code for showing the suspension message as per the churn, trial and lite plan.
- Added the message in localized file to get multi lingual capability for this message.
- Updated the logic of showing of suspension screen.
- Added the Plan Code 111 as Trial plan.

## Images
<img src = 'https://github.com/user-attachments/assets/35e2a702-f14f-4882-8407-82ca7fe0c71a' height = '400'> <img src = 'https://github.com/user-attachments/assets/b7a123e2-c5b0-42ae-8faf-3173b3ec3137' height = '400'> <img src = 'https://github.com/user-attachments/assets/ca912b13-9998-4aa0-870d-c0baaea1f9bb' height = '400'>

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `CM-2439`
KM_Core_Branch: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new trial plan in the app's pricing options.

- **Refactor**
  - Improved and simplified the logic for displaying the account suspension screen, ensuring consistent behavior across different user plans.
  - Updated internal handling to better distinguish between admin and non-admin users for suspension screen display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->