### PR TITLE
[CM-1345] Prechat lead support for Regex - iOS SDK

### DIFF
--- a/Example/Kommunicate/Base.lproj/Localizable.strings
+++ b/Example/Kommunicate/Base.lproj/Localizable.strings
@@ -30,6 +30,12 @@ PreChatViewEmailAndPhoneNumberEmptyError = "Please fill email or the phone numbe
 PreChatViewEmailInvalidError = "Please enter correct email address";
 /* Invalid Phone number error message */
 PreChatViewPhoneNumberInvalidError = "Please enter correct phone number";
+/* Invalid Email error message for custom regex */
+PreChatViewEmailRegexFailedError = "Please enter valid email address";
+/* Invalid Name error message for custom regex */
+PreChatViewNameRegexFailedError = "Please enter valid name";
+/* Invalid Password error message for custom regex */
+PreChatViewPasswordRegexFailedError = "Please enter valid password";
 /* Empty Name error message */
 PreChatViewNameEmptyError = "Please enter your name";
 /* Empty Password error message */

--- a/Sources/Kommunicate/Classes/KMPreChatFormViewController.swift
+++ b/Sources/Kommunicate/Classes/KMPreChatFormViewController.swift
@@ -35,6 +35,21 @@ open class KMPreChatFormViewController: UIViewController {
         /// user has submitted. By default, it's nil.
         /// When it's nil, we use `NSDataDetector` to validate the phone number.
         public var phoneNumberRegexPattern: String?
+        
+        /// The regular expression pattern that will be used to validate the name
+        /// user has entered. By default, it's nil.
+        /// When it's nil, basic non-empty string validation can be applied.
+        public var nameRegexPattern: String?
+
+        /// The regular expression pattern that will be used to validate the email
+        /// user has submitted. By default, it's nil.
+        /// When it's nil, default email format validation will be used.
+        public var emailRegexPattern: String?
+
+        /// The regular expression pattern that will be used to validate the password
+        /// user has submitted. By default, it's nil.
+        /// When it's nil, fallback password validation may be applied.
+        public var passwordRegexPattern: String?
 
         public init() {}
     }
@@ -61,6 +76,9 @@ open class KMPreChatFormViewController: UIViewController {
     enum TextFieldValidationError: Error, Localizable {
         case emailAndPhoneNumberEmpty
         case invalidEmailAddress
+        case invalidCustomEmailRegex
+        case invalidCustomNameRegex
+        case invalidCustomPasswordRegex
         case invalidPhoneNumber
         case emptyName
         case emptyEmailAddress
@@ -85,6 +103,12 @@ open class KMPreChatFormViewController: UIViewController {
                 return localizedString(forKey: "PreChatViewPhoneNumberEmptyError", fileName: fileName)
             case .emptyPassword:
                 return localizedString(forKey: "PreChatViewPasswordEmptyError", fileName: fileName)
+            case .invalidCustomEmailRegex:
+                return localizedString(forKey: "PreChatViewEmailRegexFailedError", fileName: fileName)
+            case .invalidCustomNameRegex:
+                return localizedString(forKey: "PreChatViewNameRegexFailedError", fileName: fileName)
+            case .invalidCustomPasswordRegex:
+                return localizedString(forKey: "PreChatViewPasswordRegexFailedError", fileName: fileName)
             }
         }
     }
@@ -291,32 +315,57 @@ open class KMPreChatFormViewController: UIViewController {
         outerLoop: for mandatoryOption in preChatConfiguration.mandatoryOptions {
             switch mandatoryOption {
             case .email:
-                if let emailText = emailTextField.text,
-                   !emailText.isEmpty, !emailText.isValidEmail {
-                    validationError = TextFieldValidationError.invalidEmailAddress
+                guard let emailText = emailTextField.text, !emailText.isEmpty else {
+                    validationError = .invalidEmailAddress
                     break outerLoop
                 }
+
+                if !emailText.isValidEmail {
+                    validationError = .invalidEmailAddress
+                    break outerLoop
+                }
+
+                if let pattern = preChatConfiguration.emailRegexPattern,
+                   !emailText.matchesWithPattern(pattern) {
+                    validationError = .invalidCustomEmailRegex
+                    break outerLoop
+                }
+
             case .name:
-                if let nameText = nameTextField.text, nameText.isEmpty {
-                    validationError = TextFieldValidationError.emptyName
+                guard let nameText = nameTextField.text, !nameText.isEmpty else {
+                    validationError = .emptyName
+                    break outerLoop
+                }
+
+                if let pattern = preChatConfiguration.nameRegexPattern,
+                   !nameText.matchesWithPattern(pattern) {
+                    validationError = .invalidCustomNameRegex
                     break outerLoop
                 }
 
             case .password:
-                if let passwordText = passwordTextField.text, passwordText.isEmpty {
-                    validationError = TextFieldValidationError.emptyPassword
+                guard let passwordText = passwordTextField.text, !passwordText.isEmpty else {
+                    validationError = .emptyPassword
+                    break outerLoop
+                }
+
+                if let pattern = preChatConfiguration.passwordRegexPattern,
+                   !passwordText.matchesWithPattern(pattern) {
+                    validationError = .invalidCustomPasswordRegex
                     break outerLoop
                 }
 
             case .phoneNumber:
-                let isValidNumber: ((String) -> Bool) = { number in
-                    self.preChatConfiguration.phoneNumberRegexPattern != nil ?
-                        number.matchesWithPattern(self.preChatConfiguration.phoneNumberRegexPattern ?? "") : number.isValidPhoneNumber
+                guard let phoneText = phoneNumberTextField.text, !phoneText.isEmpty else {
+                    continue // optional empty allowed
                 }
 
-                if let phoneNumberText = phoneNumberTextField.text,
-                   !phoneNumberText.isEmpty, !isValidNumber(phoneNumberText) {
-                    validationError = TextFieldValidationError.invalidPhoneNumber
+                let isValid = preChatConfiguration.phoneNumberRegexPattern.map {
+                    phoneText.matchesWithPattern($0)
+                } ?? phoneText.isValidPhoneNumber
+
+                if !isValid {
+                    validationError = .invalidPhoneNumber
                     break outerLoop
                 }
             }

--- a/Sources/Resources/Assets/KMPreChatUserFormView.xib
+++ b/Sources/Resources/Assets/KMPreChatUserFormView.xib
@@ -223,11 +223,8 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SM4-Ob-Uc2">
                             <rect key="frame" x="0.0" y="494" width="345" height="76"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WpO-nN-HX8">
+                                <label opaque="NO" userInteractionEnabled="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WpO-nN-HX8">
                                     <rect key="frame" x="0.0" y="0.0" width="345" height="40"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="40" id="lWF-bt-dxh"/>
-                                    </constraints>
                                     <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="16"/>
                                     <color key="textColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>

--- a/Sources/Resources/Assets/Localizable.strings
+++ b/Sources/Resources/Assets/Localizable.strings
@@ -26,6 +26,12 @@ PreChatViewEmailAndPhoneNumberEmptyError = "Please fill email or the phone numbe
 PreChatViewEmailInvalidError = "Please enter correct email address";
 /* Invalid Phone number error message */
 PreChatViewPhoneNumberInvalidError = "Please enter correct phone number";
+/* Invalid Email error message for custom regex */
+PreChatViewEmailRegexFailedError = "Please enter valid email address";
+/* Invalid Name error message for custom regex */
+PreChatViewNameRegexFailedError = "Please enter valid name";
+/* Invalid Password error message for custom regex */
+PreChatViewPasswordRegexFailedError = "Please enter valid password";
 /* Empty Name error message */
 PreChatViewNameEmptyError = "Please enter your name";
 /* Empty Email error message */


### PR DESCRIPTION
## Summary
- Added a Regex for name, email, password.
- Also Localized the error labels for easy customization.

## Example Code 
```
preChatVC.preChatConfiguration.optionsToShow = [.email, .name, .phoneNumber, .password] // Configure options to be visible in pre-chat
preChatVC.preChatConfiguration.mandatoryOptions = [.email, .name, .phoneNumber, .password] // Configure mandatory options
preChatVC.preChatConfiguration.passwordRegexPattern = "^(?=.*[A-Z])(?=.*\\d)(?=.*[^a-zA-Z\\d]).{8,}$"
preChatVC.preChatConfiguration.nameRegexPattern = "^[A-Z][a-z]{0,13}$"
preChatVC.preChatConfiguration.emailRegexPattern = "^[A-Za-z0-9._%+-]+@(gmail\\.com|hotmail\\.com)$"
preChatVC.preChatConfiguration.phoneNumberRegexPattern = "^[0-9]{10}$"
``` 

## Localizable Keys
```
/* Invalid Email error message for custom regex */
PreChatViewEmailRegexFailedError = "Please enter valid email address";
/* Invalid Name error message for custom regex */
PreChatViewNameRegexFailedError = "Please enter valid name";
/* Invalid Password error message for custom regex */
PreChatViewPasswordRegexFailedError = "Please enter valid password";
```

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `dev`
KM_Core_Branch: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom regular expression validation for name, email, and password fields in the pre-chat form.
  - Introduced specific error messages for invalid name, email, and password inputs when custom validation fails.
- **Improvements**
  - Enhanced pre-chat form validation logic for more precise feedback on input errors.
  - Updated label in the pre-chat user form to allow unlimited lines and dynamic height adjustment for better display of error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->