### PR TITLE
Update navigation bar button appearance and behaviour

### DIFF
--- a/Sources/Kommunicate/Classes/FaqViewController.swift
+++ b/Sources/Kommunicate/Classes/FaqViewController.swift
@@ -79,8 +79,18 @@ public class FaqViewController: UIViewController, Localizable {
 
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationItem.leftBarButtonItem = getBackArrowButton(target: self, action: #selector(backTapped))
+        var backButton = getBackArrowButton(target: self, action: #selector(backTapped))
         navigationItem.title = localizedString(forKey: "FaqTitle", fileName: configuration.localizedStringFileName)
+        backButton.tintColor = configuration.bottomSheetNavIconColor
+        navigationItem.leftBarButtonItem = backButton
+        if #available(iOS 26.0, *) {
+            navigationItem.rightBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+            navigationItem.leftBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+        }
     }
 
     @objc func backTapped() {

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -113,6 +113,7 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
             target: self, action: #selector(compose)
         )
         barButton.accessibilityIdentifier = "startNewIcon"
+        barButton.tintColor = configuration.navCreateConversationIconColor
         return barButton
     }()
 
@@ -384,9 +385,21 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
         guard !configuration.hideBackButtonInConversationList else { return }
         
         if configuration.enableBackArrowOnConversationListScreen {
-            navigationItem.leftBarButtonItem = getBackArrowButton(target: self, action: #selector(customBackAction))
+            let backArrowButton = getBackArrowButton(target: self, action: #selector(customBackAction))
+            backArrowButton.tintColor = configuration.conversationListScreenBackButtonColor
+            navigationItem.leftBarButtonItem = backArrowButton
         } else {
-            navigationItem.leftBarButtonItem = getBackTextButton(title: LocalizedText.leftBarBackButtonText, target: self, action: #selector(customBackAction))
+            let backTextButton = getBackTextButton(title: LocalizedText.leftBarBackButtonText, target: self, action: #selector(customBackAction))
+            backTextButton.tintColor = configuration.conversationListScreenBackButtonColor
+            navigationItem.leftBarButtonItem = backTextButton
+        }
+        if #available(iOS 26.0, *) {
+            navigationItem.rightBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+            navigationItem.leftBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
         }
     }
 
@@ -418,6 +431,14 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
             let rightButtons = rightBarButtonItems.prefix(3)
             navigationItem.rightBarButtonItems = Array(rightButtons)
         }
+        if #available(iOS 26.0, *) {
+            navigationItem.rightBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+            navigationItem.leftBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+        }
     }
 
     func setupSearchController() {
@@ -431,7 +452,15 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
         navigationItem.rightBarButtonItems = nil
         navigationItem.leftBarButtonItems = nil
         navigationItem.titleView = searchBar
-
+        
+        if #available(iOS 26.0, *) {
+            navigationItem.rightBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+            navigationItem.leftBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+        }
         UIView.animate(
             withDuration: 0.5,
             animations: { self.searchBar.show(true) },

--- a/Sources/Kommunicate/Classes/KMConversationListViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationListViewController.swift
@@ -393,14 +393,7 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
             backTextButton.tintColor = configuration.conversationListScreenBackButtonColor
             navigationItem.leftBarButtonItem = backTextButton
         }
-        if #available(iOS 26.0, *) {
-            navigationItem.rightBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-            navigationItem.leftBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-        }
+        configureNavigationBarButtonsForIOS26()
     }
 
     func setupNavigationRightButtons() {
@@ -431,14 +424,7 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
             let rightButtons = rightBarButtonItems.prefix(3)
             navigationItem.rightBarButtonItems = Array(rightButtons)
         }
-        if #available(iOS 26.0, *) {
-            navigationItem.rightBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-            navigationItem.leftBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-        }
+        configureNavigationBarButtonsForIOS26()
     }
 
     func setupSearchController() {
@@ -453,14 +439,7 @@ public class KMConversationListViewController: KMChatBaseViewController, Localiz
         navigationItem.leftBarButtonItems = nil
         navigationItem.titleView = searchBar
         
-        if #available(iOS 26.0, *) {
-            navigationItem.rightBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-            navigationItem.leftBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-        }
+        configureNavigationBarButtonsForIOS26()
         UIView.animate(
             withDuration: 0.5,
             animations: { self.searchBar.show(true) },

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -704,6 +704,14 @@ open class KMConversationViewController: KMChatConversationViewController, KMUpd
         // Remove current title from center of navigation bar
         navigationItem.titleView = UIView()
         navigationItem.leftBarButtonItems = nil
+        if #available(iOS 26.0, *) {
+            navigationItem.rightBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+            navigationItem.leftBarButtonItems?.forEach {
+                $0.hidesSharedBackground = true
+            }
+        }
         // Create custom navigation view.
         let (contact, channel) = conversationDetail.conversationAssignee(groupId: viewModel.channelKey, userId: viewModel.contactId)
         if let alChannel = channel {

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -704,7 +704,6 @@ open class KMConversationViewController: KMChatConversationViewController, KMUpd
         // Remove current title from center of navigation bar
         navigationItem.titleView = UIView()
         navigationItem.leftBarButtonItems = nil
-        configureNavigationBarButtonsForIOS26()
         // Create custom navigation view.
         let (contact, channel) = conversationDetail.conversationAssignee(groupId: viewModel.channelKey, userId: viewModel.contactId)
         if let alChannel = channel {
@@ -725,6 +724,7 @@ open class KMConversationViewController: KMChatConversationViewController, KMUpd
         assigneeUserId = contact?.userId
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: customNavigationView)
         updateAssigneeDetails()
+        configureNavigationBarButtonsForIOS26()
       }
 
     override public func refreshViewController() {

--- a/Sources/Kommunicate/Classes/KMConversationViewController.swift
+++ b/Sources/Kommunicate/Classes/KMConversationViewController.swift
@@ -704,14 +704,7 @@ open class KMConversationViewController: KMChatConversationViewController, KMUpd
         // Remove current title from center of navigation bar
         navigationItem.titleView = UIView()
         navigationItem.leftBarButtonItems = nil
-        if #available(iOS 26.0, *) {
-            navigationItem.rightBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-            navigationItem.leftBarButtonItems?.forEach {
-                $0.hidesSharedBackground = true
-            }
-        }
+        configureNavigationBarButtonsForIOS26()
         // Create custom navigation view.
         let (contact, channel) = conversationDetail.conversationAssignee(groupId: viewModel.channelKey, userId: viewModel.contactId)
         if let alChannel = channel {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Adds tintColor customization for navigation bar buttons in FAQ and conversation list screens.
- Sets hidesSharedBackground for navigation bar items on iOS 26+ to improve UI consistency.
- Ensures back button and create conversation icon use configurable colors.

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `fix-ios26-glass-effect`
KM_Core_Branch: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced navigation button styling with customizable tint colors across conversation and FAQ screens.
  * Improved visual treatment of navigation bar buttons on iOS 26.0 and later for a cleaner interface appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->