### PR TITLE
Pod update to1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for [Kommunicate-iOS-SDK](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/releases) on Github.
 
+## [7.3.2] 2025-10-22
+- Fixed the glass effect bug with iOS 26 versions.
+- Fixed dark icon issue with iOS 26 versions.
+
 ## [7.3.1] 2025-09-16
 - PreChat Lead Regex support added.
 - New Login and Create Conversation Function Exposed.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -15,19 +15,19 @@ PODS:
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
   - Kingfisher (7.10.2)
-  - Kommunicate (7.3.1):
-    - KommunicateChatUI-iOS-SDK (= 1.5.1)
-  - KommunicateChatUI-iOS-SDK (1.5.1):
-    - KommunicateChatUI-iOS-SDK/Complete (= 1.5.1)
-  - KommunicateChatUI-iOS-SDK/Complete (1.5.1):
+  - Kommunicate (7.3.2):
+    - KommunicateChatUI-iOS-SDK (= 1.5.2)
+  - KommunicateChatUI-iOS-SDK (1.5.2):
+    - KommunicateChatUI-iOS-SDK/Complete (= 1.5.2)
+  - KommunicateChatUI-iOS-SDK/Complete (1.5.2):
     - iOSDropDown
     - Kingfisher (~> 7.10.0)
     - KommunicateChatUI-iOS-SDK/RichMessageKit
     - KommunicateCore-iOS-SDK (= 1.3.1)
     - SwipeCellKit (~> 2.7.1)
-  - KommunicateChatUI-iOS-SDK/RichMessageKit (1.5.1)
+  - KommunicateChatUI-iOS-SDK/RichMessageKit (1.5.2)
   - KommunicateCore-iOS-SDK (1.3.1)
-  - Nimble (13.7.1):
+  - Nimble (13.8.0):
     - CwlPreconditionTesting (~> 2.2.0)
   - Nimble-Snapshots (9.8.0):
     - Nimble-Snapshots/Core (= 9.8.0)
@@ -35,7 +35,7 @@ PODS:
     - iOSSnapshotTestCase (~> 8.0)
     - Nimble (~> 13.0)
   - Quick (7.6.2)
-  - SwiftLint (0.61.0)
+  - SwiftLint (0.62.1)
   - SwipeCellKit (2.7.1)
 
 DEPENDENCIES:
@@ -77,13 +77,13 @@ SPEC CHECKSUMS:
   iOSDropDown: ce9daa584eaa5567cafc1b633e3cc7eb6d9cea42
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kingfisher: 99edc495d3b7607e6425f0d6f6847b2abd6d716d
-  Kommunicate: 069586b660165c54838f7c436b437a20d50ff24b
-  KommunicateChatUI-iOS-SDK: c1cd92cbe0cde3ce9684b4a269c599ae110e3c29
+  Kommunicate: 90eb31b6e840522c7704f4fd3d14d2d5840431b0
+  KommunicateChatUI-iOS-SDK: 58362240dfcd580de4f8ac6fb04a32b83bf49df5
   KommunicateCore-iOS-SDK: 90a88f9bd76a4fc53984e925027ae80d60b04ea3
-  Nimble: 317d713c30c3336dd8571da1889f7ec3afc626e8
+  Nimble: 84982ec98b5dfc0ffe9ae2ed4c0b2fc57807c2d5
   Nimble-Snapshots: 240ea76ee8e52dfc1387b8d0d9bf1db3420cabbd
   Quick: b8bec97cd4b9f21da0472d45580f763b801fc353
-  SwiftLint: bf6da11a31c6644a0bbb27f4fa15fd9636db00b3
+  SwiftLint: 6a9eb020853558a7eaf00f655636b5d6ad15bd02
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
 PODFILE CHECKSUM: 66d2e2045cc91de55d1206f11783b1e0e5544df4

--- a/Kommunicate.podspec
+++ b/Kommunicate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Kommunicate'
-  s.version = '7.3.1'
+  s.version = '7.3.2'
   s.summary = 'Kommunicate iOS SDK for customer support.'
   s.homepage = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK'
   s.license = { :type => 'BSD-3-Clause', :file => 'LICENSE' }
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.source_files = 'Sources/Kommunicate/Classes/**/*.{swift}'
   s.resources = 'Sources/Resources/**/*{lproj,storyboard,xib,xcassets,json,strings}'
-  s.dependency 'KommunicateChatUI-iOS-SDK' , '1.5.1'
+  s.dependency 'KommunicateChatUI-iOS-SDK' , '1.5.2'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git",
         "state": {
           "branch": null,
-          "revision": "157dc4cf4702b5b815a0fa0012cb6a170828b5e1",
-          "version": "1.5.1"
+          "revision": "4da6dc6fe1ed2c49bac98fc5e755a84c142cb2eb",
+          "version": "1.5.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-            .package(name: "KommunicateChatUI-iOS-SDK", url: "https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git", from: "1.5.1"),
+            .package(name: "KommunicateChatUI-iOS-SDK", url: "https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git", from: "1.5.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

- Updated KommunicateChatUI-iOS-SDK dependency to version 1.5.2 in Podspec, Swift Package, and lock files.
- Updated changelog for 7.3.2 release.
- Documented fixes for glass effect and dark icon issues on iOS 26.

## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `dev`
KM_Core_Branch: `dev`