### PR TITLE
TDH-3841: Adding Message Metadata support

### DIFF
--- a/Example/Tests/MessageMetadataTests.swift
+++ b/Example/Tests/MessageMetadataTests.swift
@@ -12,13 +12,23 @@ import XCTest
 
 class MessageMetadataTests: XCTestCase {
     var config: KMConfiguration!
+    var defaultConfiguration: KMConfiguration!
 
     var messageMetadata: [AnyHashable: Any]? {
         return config.messageMetadata
     }
 
     override func setUp() {
+        super.setUp()
+        defaultConfiguration = Kommunicate.defaultConfiguration
         config = KMConfiguration()
+    }
+
+    override func tearDown() {
+        Kommunicate.defaultConfiguration = defaultConfiguration
+        defaultConfiguration = nil
+        config = nil
+        super.tearDown()
     }
 
     func testChatContextUpdate() throws {
@@ -57,6 +67,22 @@ class MessageMetadataTests: XCTestCase {
 
         let chatInfo = try XCTUnwrap(context["chatInfo"] as? String)
         XCTAssertEqual(chatInfo, "chat info value")
+    }
+
+    func testMessageBuilderMetadataIncludesDefaultConfigurationMetadata() throws {
+        try config.updateChatContext(with: ["chatInfo": "chat info value"])
+        Kommunicate.defaultConfiguration = config
+
+        let message = KMMessageBuilder()
+            .withText("hello")
+            .withMetadata(["customKey": "custom value"])
+            .build()
+
+        let metadata = try XCTUnwrap(message.toKMCoreMessage().metadata as? [AnyHashable: Any])
+        let context = try XCTUnwrap(chatContextFromMetadata(metadata))
+
+        XCTAssertEqual(context["chatInfo"] as? String, "chat info value")
+        XCTAssertEqual(metadata["customKey"] as? String, "custom value")
     }
 
     private func chatContextFromMetadata(_ metadata: [AnyHashable: Any]) throws -> [String: Any]? {

--- a/Sources/Kommunicate/Classes/Models/KMMessageBuilder.swift
+++ b/Sources/Kommunicate/Classes/Models/KMMessageBuilder.swift
@@ -59,9 +59,18 @@ extension KMMessage {
         alMessage.source = Int16(AL_SOURCE_IOS)
         alMessage.conversationId = nil
         alMessage.groupId = nil
-        if let metadata = metadata {
+        let metadata = mergedMetadataWithDefaultConfiguration()
+        if !metadata.isEmpty {
             alMessage.metadata = NSMutableDictionary(dictionary: metadata)
         }
         return alMessage
+    }
+
+    private func mergedMetadataWithDefaultConfiguration() -> [AnyHashable: Any] {
+        var metadata = Kommunicate.defaultConfiguration.messageMetadata ?? [:]
+        self.metadata?.forEach { key, value in
+            metadata[key] = value
+        }
+        return metadata
     }
 }

--- a/Sources/Kommunicate/Classes/Models/KMMessageBuilder.swift
+++ b/Sources/Kommunicate/Classes/Models/KMMessageBuilder.swift
@@ -59,6 +59,9 @@ extension KMMessage {
         alMessage.source = Int16(AL_SOURCE_IOS)
         alMessage.conversationId = nil
         alMessage.groupId = nil
+        if let metadata = metadata {
+            alMessage.metadata = NSMutableDictionary(dictionary: metadata)
+        }
         return alMessage
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- When sending a message programmatically via Kommunicate.sendMessage(message:) with metadata set through KMMessageBuilder().withMetadata(...) (or KMMessage.metadata), the custom metadata fields never reach the outgoing message payload that the server/bot/webhook receives. Only the SDK-internal KM_CHAT_CONTEXT key appears.

- This affects both native iOS integrations and React Native (react-native-kommunicate-chat), and is a regression vs. Android, where the same metadata is delivered correctly.
- 
## Testing Branches
<!-- Which branch the code should be tested? Add the code in `<BRANCH_NAME>`. -->
KM_ChatUI_Branch : `dev`
KM_Core_Branch: `dev`